### PR TITLE
fix: add translateble false to generated android strings

### DIFF
--- a/lib/common/templates/android/strings.template
+++ b/lib/common/templates/android/strings.template
@@ -20,6 +20,6 @@ var props = dictionary.allTokens.filter(function(prop) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% props.forEach(function(prop) {
-  %><string name="<%= prop.name %>"><%= prop.value %></string><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
+  %><string name="<%= prop.name %>" translateble="false"><%= prop.value %></string><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>

--- a/lib/common/templates/android/strings.template
+++ b/lib/common/templates/android/strings.template
@@ -20,6 +20,6 @@ var props = dictionary.allTokens.filter(function(prop) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% props.forEach(function(prop) {
-  %><string name="<%= prop.name %>" translateble="false"><%= prop.value %></string><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
+  %><string name="<%= prop.name %>" translatable="false"><%= prop.value %></string><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>


### PR DESCRIPTION
*#893*

*Description of changes:*

Add translatable="false" attribute to the generated strings. I assume it is default and only one correct use of these strings.

Android documentation is here http://tools.android.com/recent/non-translatablestrings

It would be also great to add test for it here https://github.com/amzn/style-dictionary/blob/main/__tests__/formats/androidResources.test.js
