### PR TITLE
fix(formats): added nested property to json/asset

### DIFF
--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -1263,3 +1263,4 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
 module.exports['json/nested'].nested = true;
 module.exports['javascript/module'].nested = true;
 module.exports['javascript/object'].nested = true;
+module.exports["json/asset"].nested = true;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We are getting a lot of warnings during tokens' generation mentioning name collisions.

I started looking into this and discovered the `nested` format idea, which works great for the formats where it's set up (and we had to add it to a few of our formats), but then I realized I was still getting errors during asset files generation with the `json/format` format.
Looking at the code + at its output, it seems like this format is a nested format too, but I am guessing it was missed during the time where nested formats where introduced.

So this PR is just making the `json/format` officially a `nested` format, so there won't be anymore wrong warnings for it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
