### PR TITLE
feat: add preExpand meta info to expanded tokens

### DIFF
--- a/.changeset/swift-scissors-cover.md
+++ b/.changeset/swift-scissors-cover.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': minor
+---
+
+When expanding object-value tokens, add some metadata about what type the token belonged to before expanding, and which property. This is useful e.g. for transforms to target specific object-value properties like lineHeights. When expanding, the type is aligned to the `number` type (DTCG), but you may want to transform `lineHeight` (not a known DTCG type) tokens but not all `number` tokens.

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -532,14 +532,38 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
           color: {
             type: 'color',
             value: '#000',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'color',
+                  type: 'border',
+                },
+              },
+            },
           },
           style: {
             type: 'strokeStyle',
             value: 'solid',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'style',
+                  type: 'border',
+                },
+              },
+            },
           },
           width: {
             type: 'dimension',
             value: '2px',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'width',
+                  type: 'border',
+                },
+              },
+            },
           },
         },
       });
@@ -573,14 +597,38 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
           color: {
             type: 'color',
             value: '#000',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'color',
+                  type: 'border',
+                },
+              },
+            },
           },
           style: {
             type: 'strokeStyle',
             value: 'solid',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'style',
+                  type: 'border',
+                },
+              },
+            },
           },
           width: {
             type: 'dimension',
             value: '2px',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'width',
+                  type: 'border',
+                },
+              },
+            },
           },
         },
       });
@@ -631,14 +679,38 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
           color: {
             type: 'color',
             value: '#000',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'color',
+                  type: 'border',
+                },
+              },
+            },
           },
           style: {
             type: 'strokeStyle',
             value: 'solid',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'style',
+                  type: 'border',
+                },
+              },
+            },
           },
           width: {
             type: 'dimension',
             value: '2px',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'width',
+                  type: 'border',
+                },
+              },
+            },
           },
         },
         borderTwo: input.borderTwo,
@@ -648,28 +720,76 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
           color: {
             type: 'color',
             value: '#000',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'color',
+                  type: 'border',
+                },
+              },
+            },
           },
           style: {
             type: 'strokeStyle',
             value: 'solid',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'style',
+                  type: 'border',
+                },
+              },
+            },
           },
           width: {
             type: 'dimension',
             value: '2px',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'width',
+                  type: 'border',
+                },
+              },
+            },
           },
         },
         borderTwo: {
           color: {
             type: 'color',
             value: '#ccc',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'color',
+                  type: 'border',
+                },
+              },
+            },
           },
           style: {
             type: 'strokeStyle',
             value: 'dashed',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'style',
+                  type: 'border',
+                },
+              },
+            },
           },
           width: {
             type: 'dimension',
             value: '1px',
+            $extensions: {
+              'com.styledictionary': {
+                preExpand: {
+                  prop: 'width',
+                  type: 'border',
+                },
+              },
+            },
           },
         },
       });

--- a/__tests__/utils/expandObjectTokens.test.js
+++ b/__tests__/utils/expandObjectTokens.test.js
@@ -36,14 +36,38 @@ const borderOutput = {
   color: {
     type: 'color',
     value: '#000',
+    $extensions: {
+      'com.styledictionary': {
+        preExpand: {
+          prop: 'color',
+          type: 'border',
+        },
+      },
+    },
   },
   style: {
     type: 'strokeStyle',
     value: 'solid',
+    $extensions: {
+      'com.styledictionary': {
+        preExpand: {
+          prop: 'style',
+          type: 'border',
+        },
+      },
+    },
   },
   width: {
     type: 'dimension',
     value: '2px',
+    $extensions: {
+      'com.styledictionary': {
+        preExpand: {
+          prop: 'width',
+          type: 'border',
+        },
+      },
+    },
   },
 };
 
@@ -51,14 +75,38 @@ const typographyOutput = {
   fontWeight: {
     type: 'fontWeight',
     value: '800',
+    $extensions: {
+      'com.styledictionary': {
+        preExpand: {
+          prop: 'fontWeight',
+          type: 'typography',
+        },
+      },
+    },
   },
   fontSize: {
     type: 'dimension',
     value: '16px',
+    $extensions: {
+      'com.styledictionary': {
+        preExpand: {
+          prop: 'fontSize',
+          type: 'typography',
+        },
+      },
+    },
   },
   fontFamily: {
     type: 'fontFamily',
     value: 'Arial Black',
+    $extensions: {
+      'com.styledictionary': {
+        preExpand: {
+          prop: 'fontFamily',
+          type: 'typography',
+        },
+      },
+    },
   },
 };
 
@@ -118,16 +166,40 @@ describe('utils', () => {
               type: 'color',
               value: '#000',
               path: ['input', 'border', 'color'],
+              $extensions: {
+                'com.styledictionary': {
+                  preExpand: {
+                    prop: 'color',
+                    type: 'border',
+                  },
+                },
+              },
             },
             style: {
               type: 'strokeStyle',
               value: 'solid',
               path: ['input', 'border', 'style'],
+              $extensions: {
+                'com.styledictionary': {
+                  preExpand: {
+                    prop: 'style',
+                    type: 'border',
+                  },
+                },
+              },
             },
             width: {
               type: 'dimension',
               value: '2px',
               path: ['input', 'border', 'width'],
+              $extensions: {
+                'com.styledictionary': {
+                  preExpand: {
+                    prop: 'width',
+                    type: 'border',
+                  },
+                },
+              },
             },
           });
         });
@@ -148,14 +220,38 @@ describe('utils', () => {
             color: {
               $type: 'color',
               $value: '#000',
+              $extensions: {
+                'com.styledictionary': {
+                  preExpand: {
+                    prop: 'color',
+                    type: 'border',
+                  },
+                },
+              },
             },
             style: {
               $type: 'strokeStyle',
               $value: 'solid',
+              $extensions: {
+                'com.styledictionary': {
+                  preExpand: {
+                    prop: 'style',
+                    type: 'border',
+                  },
+                },
+              },
             },
             width: {
               $type: 'dimension',
               $value: '2px',
+              $extensions: {
+                'com.styledictionary': {
+                  preExpand: {
+                    prop: 'width',
+                    type: 'border',
+                  },
+                },
+              },
             },
           });
         });
@@ -192,44 +288,124 @@ describe('utils', () => {
               offsetX: {
                 type: 'dimension',
                 value: '2px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'offsetX',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               offsetY: {
                 type: 'dimension',
                 value: '4px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'offsetY',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               blur: {
                 type: 'dimension',
                 value: '2px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'blur',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               spread: {
                 type: 'dimension',
                 value: '0',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'spread',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               color: {
                 type: 'color',
                 value: '#000',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'color',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
             },
             2: {
               offsetX: {
                 type: 'dimension',
                 value: '10px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'offsetX',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               offsetY: {
                 type: 'dimension',
                 value: '12px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'offsetY',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               blur: {
                 type: 'dimension',
                 value: '4px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'blur',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               spread: {
                 type: 'dimension',
                 value: '3px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'spread',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
               color: {
                 type: 'color',
                 value: '#ccc',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'color',
+                      type: 'shadow',
+                    },
+                  },
+                },
               },
             },
           });
@@ -388,26 +564,80 @@ describe('utils', () => {
               dashArray: {
                 value: ['0.5rem', '0.25rem'],
                 type: 'dimension',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'dashArray',
+                      type: 'strokeStyle',
+                    },
+                  },
+                },
               },
               lineCap: {
                 value: 'round',
                 type: 'lineCap',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'lineCap',
+                      type: 'strokeStyle',
+                    },
+                  },
+                },
               },
             },
             border: {
               // color can remain unresolved ref because its resolved value is not an object
-              color: { value: '{black}', type: 'color' },
-              width: { value: '3px', type: 'dimension' },
+              color: {
+                value: '{black}',
+                type: 'color',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'color',
+                      type: 'border',
+                    },
+                  },
+                },
+              },
+              width: {
+                value: '3px',
+                type: 'dimension',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'width',
+                      type: 'border',
+                    },
+                  },
+                },
+              },
               // style must be its resolved value because it is an object and potentially gets expanded,
               // breaking the original reference
               style: {
                 dashArray: {
                   value: ['0.5rem', '0.25rem'],
                   type: 'dimension',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'dashArray',
+                        type: 'strokeStyle',
+                      },
+                    },
+                  },
                 },
                 lineCap: {
                   value: 'round',
                   type: 'lineCap',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'lineCap',
+                        type: 'strokeStyle',
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -448,44 +678,124 @@ describe('utils', () => {
                 offsetX: {
                   type: 'dimension',
                   value: '2px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'offsetX',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 offsetY: {
                   type: 'dimension',
                   value: '4px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'offsetY',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 blur: {
                   type: 'dimension',
                   value: '2px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'blur',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 spread: {
                   type: 'dimension',
                   value: '0',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'spread',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 color: {
                   type: 'color',
                   value: '#000',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'color',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
               },
               2: {
                 offsetX: {
                   type: 'dimension',
                   value: '10px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'offsetX',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 offsetY: {
                   type: 'dimension',
                   value: '12px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'offsetY',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 blur: {
                   type: 'dimension',
                   value: '4px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'blur',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 spread: {
                   type: 'dimension',
                   value: '3px',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'spread',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
                 color: {
                   type: 'color',
                   value: '#ccc',
+                  $extensions: {
+                    'com.styledictionary': {
+                      preExpand: {
+                        prop: 'color',
+                        type: 'shadow',
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -517,28 +827,76 @@ describe('utils', () => {
               color: {
                 $type: 'color',
                 $value: '#000',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'color',
+                      type: 'border',
+                    },
+                  },
+                },
               },
               style: {
                 $type: 'strokeStyle',
                 $value: 'solid',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'style',
+                      type: 'border',
+                    },
+                  },
+                },
               },
               width: {
                 $type: 'dimension',
                 $value: '2px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'width',
+                      type: 'border',
+                    },
+                  },
+                },
               },
             },
             borderRef: {
               color: {
                 $type: 'color',
                 $value: '#000',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'color',
+                      type: 'border',
+                    },
+                  },
+                },
               },
               style: {
                 $type: 'strokeStyle',
                 $value: 'solid',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'style',
+                      type: 'border',
+                    },
+                  },
+                },
               },
               width: {
                 $type: 'dimension',
                 $value: '2px',
+                $extensions: {
+                  'com.styledictionary': {
+                    preExpand: {
+                      prop: 'width',
+                      type: 'border',
+                    },
+                  },
+                },
               },
             },
           });

--- a/lib/utils/expandObjectTokens.js
+++ b/lib/utils/expandObjectTokens.js
@@ -178,11 +178,22 @@ export function expandToken(token, opts, platform) {
       expandedTokenObjRef = expandedTokenObjRef[index + 1];
     }
     Object.entries(objectVal).forEach(([key, value]) => {
-      expandedTokenObjRef[key] = {
-        ...copyMeta,
+      expandedTokenObjRef[key] = deepmerge(copyMeta, {
         [`${uses$ ? '$' : ''}value`]: value,
         [`${uses$ ? '$' : ''}type`]: getTypeFromMap(key, compositionType, typesMap),
-      };
+        // store the original composite token type as well as which prop it was
+        // so that for example a lineHeight property of a typography token, when expanded
+        // can still be matched as a lineHeight token, even though its type is now "number" after the expansion
+        $extensions: {
+          'com.styledictionary': {
+            preExpand: {
+              type: compositionType,
+              prop: key,
+            },
+          },
+        },
+      });
+
       if (Array.isArray(expandedTokenObjRef[key].path)) {
         // if we're expanding on platform level, we already have a path property
         // we will need to adjust this by adding the new keys of th expanded tokens to the path array


### PR DESCRIPTION
_Issue #, if available:_
A user has told me that it's kinda difficult for him to apply custom transforms to typography token properties such as letterSpacing or lineHeight, because after expanding them they are typed as `dimension`/`number` respectively, and therefore it's hard to set a filter function that matches only letterSpacing/lineHeight tokens when the types have been aligned / reduced to DTCG types.

_Description of changes:_

Add metadata under `$extensions.['com.styledictionary']` (where metadata should go from now on, following DTCG guidelines) so you can set a transform filter that targets expanded typography -> lineHeight tokens

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
