### PR TITLE
Android support for fonts & textCase via textAllCaps

### DIFF
--- a/__tests__/formats/__snapshots__/androidResources.test.snap.js
+++ b/__tests__/formats/__snapshots__/androidResources.test.snap.js
@@ -41,3 +41,16 @@ snapshots["formats android/resources with resourceMap override should match snap
 </resources>`;
 /* end snapshot formats android/resources with resourceMap override should match snapshot */
 
+snapshots["formats android/resources with type & textCase should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<resources>
+  <item name="headline-font" type="font">@font/comic_sans_bold</item>
+  <item name="copytext-font" type="font">@font/comic_sans</item>
+  <bool name="headline-text-eslintcase">true</bool>
+  <bool name="copytext-text-case">false</bool>
+</resources>`;
+/* end snapshot formats android/resources with type & textCase should match snapshot */

--- a/__tests__/formats/androidResources.test.js
+++ b/__tests__/formats/androidResources.test.js
@@ -89,6 +89,49 @@ const customTokens = {
   },
 };
 
+const fontAndTextCaseTokens = {
+  typo: {
+    headline: {
+      name: 'headline-font',
+      value: '@font/comic_sans_bold',
+      type: 'fontFamily',
+      original: {
+        value: '@font/comic_sans_bold',
+        type: 'fontFamily',
+      },
+    },
+    copytext: {
+      name: 'copytext-font',
+      value: '@font/comic_sans',
+      type: 'fontFamily',
+      original: {
+        value: '@font/comic_sans',
+        type: 'fontFamily',
+      },
+    },
+  },
+  textCase: {
+    headline: {
+      name: 'headline-text-case',
+      value: 'true',
+      type: 'textCase',
+      original: {
+        value: 'true',
+        type: 'textCase',
+      },
+    },
+    copytext: {
+      name: 'copytext-text-case',
+      value: 'false',
+      type: 'textCase',
+      original: {
+        value: 'none',
+        type: 'textCase',
+      },
+    },
+  },
+};
+
 const format = formats['android/resources'];
 const file = {
   destination: '__output/',
@@ -137,6 +180,19 @@ describe('formats', () => {
       const f = await format(
         createFormatArgs({
           dictionary: { tokens: customTokens, allTokens: flattenTokens(customTokens) },
+          file,
+          platform: {},
+        }),
+        {},
+        file,
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('with type & textCase should match snapshot', async () => {
+      const f = await format(
+        createFormatArgs({
+          dictionary: { fontAndTextCaseTokens, allTokens: flattenTokens(fontAndTextCaseTokens) },
           file,
           platform: {},
         }),

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -38,6 +38,7 @@ export default (opts) => {
   const resourceMap = file?.options?.resourceMap || {
     dimension: 'dimen',
     fontSize: 'dimen',
+    letterSpacing: 'dimen',
     color: 'color',
     string: 'string',
     content: 'string',

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -45,6 +45,7 @@ export default (opts) => {
     time: 'integer',
     number: 'integer',
     fontFamily: 'item',
+    textCase: 'bool',
   };
 
     /**
@@ -71,10 +72,6 @@ export default (opts) => {
       return resourceType;
     }
    
-    if (token.attributes.category === 'typography' && (token.attributes.item === 'textCase' || token.attributes.item === 'textCase')) {
-      return 'bool';
-    }
-
     if (type && resourceMap[type]) {
       return resourceMap[type];
     }

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -43,7 +43,21 @@ export default (opts) => {
     content: 'string',
     time: 'integer',
     number: 'integer',
+    fontFamily: 'item',
   };
+
+    /**
+   * @param {Token} token
+   * @param {Config} options
+   * @returns {string}
+   */
+    function additionalPropertiesForType(token, options) {
+      const type = options.usesDtcg ? token.$type : token.type;
+      if (type === 'fontFamily') {
+        return ' type="font"';
+      }
+      return ``; 
+    }
 
   /**
    * @param {Token} token
@@ -55,6 +69,11 @@ export default (opts) => {
     if (resourceType) {
       return resourceType;
     }
+   
+    if (token.attributes.category === 'typography' && (token.attributes.item === 'textCase' || token.attributes.item === 'textCase')) {
+      return 'bool';
+    }
+
     if (type && resourceMap[type]) {
       return resourceMap[type];
     }
@@ -89,7 +108,7 @@ ${header}
     /** @type {Token[]} */ (dictionary.allTokens)
       .map(
         (token) =>
-          `<${tokenToType(token, options)} name="${token.name}">${tokenToValue(
+          `<${tokenToType(token, options)} name="${token.name}"${additionalPropertiesForType(token, options)}>${tokenToValue(
             token,
             dictionary.tokens,
             options,

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -39,6 +39,8 @@ export default (opts) => {
     dimension: 'dimen',
     fontSize: 'dimen',
     letterSpacing: 'dimen',
+    lineHeight: 'dimen',
+    fontWeight: 'dimen',
     color: 'color',
     string: 'string',
     content: 'string',


### PR DESCRIPTION
As discussed earlier in [the](https://tokens-studio.slack.com/archives/C0336AEQ06Q/p1725460817459589) this PR includes two things:

1. it resolves a token of type `fontFamily` to an android-ressource entry like
`<item name="typography_body_font_family" type="font">@font/comic_sans_regular</item>`

❗️to fully support this, i also use the following transform, which is not included yet 
```
export const androidFontFamilyTransform = {
    type: "value",
    name: "android/androidFontFamilyTransform",
    transitive: true,
    filter: (token) =>
      token.attributes.item === "fontFamily" ||
      token.attributes.subitem === "fontFamily",
    transform: (token) => {
      return "@font/"+token.value;
    }
  };
```
Usage: the value can be used with https://developer.android.com/reference/android/widget/TextView#attr_android:fontFamily - please ensure that the font-file has the same name 


2. it resolves a token of type `textCase` to a bool android ressource like this:
`<bool name="typography_body_text_case">false</bool>`
❗️this also needs a transform:
```
export const androidTextCaseTransform = {
    type: "value",
    name: "android/textCaseAsBool",
    transitive: true,
    filter: (token) => {
      return token.type === "textCase";
    },
    transform: (token) => {
       return token.value === "uppercase" ? "true" : "false";
    }
  };
```
Usage: the generated resource can be used with https://developer.android.com/reference/android/widget/TextView#attr_android:textAllCaps


From our point of view, this would be a big improvement.

