### PR TITLE
docs: fix v4 migration links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <pre>
-<a href="https://styledictionary.com/version-4/migration/">What's new in Style Dictionary 4.0!</a>
+<a href="https://styledictionary.com/versions/v4/migration/">What's new in Style Dictionary 4.0!</a>
 </pre>
 
 <img src="docs/src/assets/logo.png" alt="Style Dictionary logo and mascot" title="&quot;Pascal&quot;" width="100" align="right" />

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: Migration to Version 4
-      link: /version-4/migration/
+      link: /versions/v4/migration/
       icon: up-caret
       variant: secondary
     - text: GitHub


### PR DESCRIPTION
_Issue #, if available:_ fixes #1552 

_Description of changes:_ fixes links to v4 migration guide that were redirecting to the doc site home page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
