### PR TITLE
fix: don't collision warn for identical values

### DIFF
--- a/.changeset/short-garlics-search.md
+++ b/.changeset/short-garlics-search.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix an issue with token collisions being way to eager about complaining when values that are identical are "colliding". This cuts collision warnings by 75% or more.

--- a/__integration__/logging/__snapshots__/config.test.snap.js
+++ b/__integration__/logging/__snapshots__/config.test.snap.js
@@ -2,14 +2,14 @@
 export const snapshots = {};
 snapshots["integration > logging > config > property value collisions should not throw, but notify users by default"] = 
 `
-Token collisions detected (16):
+Token collisions detected (4):
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration > logging > config > property value collisions should not throw, but notify users by default */
 
 snapshots["integration > logging > config > property value collisions should not show warnings if given higher log level"] = 
 `
-Token collisions detected (16):
+Token collisions detected (4):
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration > logging > config > property value collisions should not show warnings if given higher log level */

--- a/__integration__/tokens/size/_padding.json
+++ b/__integration__/tokens/size/_padding.json
@@ -1,10 +1,10 @@
 {
   "size": {
     "padding": {
-      "small": { "value": 0.5, "type": "dimension" },
-      "medium": { "value": 1, "type": "dimension" },
-      "large": { "value": 1, "type": "dimension" },
-      "xl": { "value": 1, "type": "dimension" }
+      "small": { "value": 0.6, "type": "dimension" },
+      "medium": { "value": 1.1, "type": "dimension" },
+      "large": { "value": 1.1, "type": "dimension" },
+      "xl": { "value": 1.1, "type": "dimension" }
     }
   }
 }

--- a/__tests__/__snapshots__/StyleDictionary.test.snap.js
+++ b/__tests__/__snapshots__/StyleDictionary.test.snap.js
@@ -23,43 +23,22 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
 
 snapshots["StyleDictionary class collisions should throw an error if the collision is in source files and log is set to error"] = 
 `
-Token collisions detected (28):
+Token collisions detected (7):
 
-Collision detected at: size.padding.zero! Original value: 0, New value: 0
-Collision detected at: size.padding.zero! Original value: dimension, New value: dimension
-Collision detected at: size.padding.zero! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.zero! Original value: true, New value: true
-Collision detected at: size.padding.tiny! Original value: 3, New value: 3
-Collision detected at: size.padding.tiny! Original value: dimension, New value: dimension
-Collision detected at: size.padding.tiny! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.tiny! Original value: true, New value: true
-Collision detected at: size.padding.small! Original value: 5, New value: 5
-Collision detected at: size.padding.small! Original value: dimension, New value: dimension
-Collision detected at: size.padding.small! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.small! Original value: true, New value: true
-Collision detected at: size.padding.base! Original value: 10, New value: 10
-Collision detected at: size.padding.base! Original value: dimension, New value: dimension
-Collision detected at: size.padding.base! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.base! Original value: true, New value: true
-Collision detected at: size.padding.large! Original value: 15, New value: 15
-Collision detected at: size.padding.large! Original value: dimension, New value: dimension
-Collision detected at: size.padding.large! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.large! Original value: true, New value: true
-Collision detected at: size.padding.xl! Original value: 20, New value: 20
-Collision detected at: size.padding.xl! Original value: dimension, New value: dimension
-Collision detected at: size.padding.xl! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.xl! Original value: true, New value: true
-Collision detected at: size.padding.xxl! Original value: 30, New value: 30
-Collision detected at: size.padding.xxl! Original value: dimension, New value: dimension
-Collision detected at: size.padding.xxl! Original value: __tests__/__tokens/_paddings.json, New value: __tests__/__tokens/_paddings.json
-Collision detected at: size.padding.xxl! Original value: true, New value: true
+Collision detected at: size.padding.zero! Original value: 0, New value: 1
+Collision detected at: size.padding.tiny! Original value: 3, New value: 4
+Collision detected at: size.padding.small! Original value: 5, New value: 6
+Collision detected at: size.padding.base! Original value: 10, New value: 11
+Collision detected at: size.padding.large! Original value: 15, New value: 16
+Collision detected at: size.padding.xl! Original value: 20, New value: 21
+Collision detected at: size.padding.xxl! Original value: 30, New value: 31
 
 `;
 /* end snapshot StyleDictionary class collisions should throw an error if the collision is in source files and log is set to error */
 
 snapshots["StyleDictionary class collisions should throw a brief error if the collision is in source files and log is set to error and verbosity default"] = 
 `
-Token collisions detected (28):
+Token collisions detected (7):
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot StyleDictionary class collisions should throw a brief error if the collision is in source files and log is set to error and verbosity default */

--- a/__tests__/__tokens/_paddings.json
+++ b/__tests__/__tokens/_paddings.json
@@ -2,31 +2,31 @@
   "size": {
     "padding": {
       "zero": {
-        "value": 0,
+        "value": 1,
         "type": "dimension"
       },
       "tiny": {
-        "value": "3",
+        "value": "4",
         "type": "dimension"
       },
       "small": {
-        "value": "5",
+        "value": "6",
         "type": "dimension"
       },
       "base": {
-        "value": "10",
+        "value": "11",
         "type": "dimension"
       },
       "large": {
-        "value": "15",
+        "value": "16",
         "type": "dimension"
       },
       "xl": {
-        "value": "20",
+        "value": "21",
         "type": "dimension"
       },
       "xxl": {
-        "value": "30",
+        "value": "31",
         "type": "dimension"
       }
     }

--- a/__tests__/utils/deepExtend.test.js
+++ b/__tests__/utils/deepExtend.test.js
@@ -106,6 +106,16 @@ describe('utils', () => {
         ).to.throw('danger danger. high voltage.');
       });
 
+      it('should not call the collision function if a collision is irrelevant because the values are identical', () => {
+        expect(() =>
+          deepExtend([{ foo: { bar: 'bar' } }, { foo: { bar: 'bar' } }], {
+            collision: function () {
+              throw new Error('danger danger. high voltage.');
+            },
+          }),
+        ).to.not.throw();
+      });
+
       it('the collision function should have the proper arguments', () => {
         const test = deepExtend([{ foo: { bar: 'bar' } }, { foo: { bar: 'baz' } }], {
           collision: function (opts) {

--- a/lib/utils/deepExtend.js
+++ b/lib/utils/deepExtend.js
@@ -89,7 +89,8 @@ export default function deepExtend(objects, opts = {}, path) {
           // Don't bring in undefined values
         } else if (copy !== undefined) {
           if (src != null) {
-            if (typeof collision == 'function') {
+            // if src & copy are the exact same value, then the collision doesn't matter
+            if (typeof collision === 'function' && src !== copy) {
               collision({ target, copy: options, path, key: name });
             }
 


### PR DESCRIPTION
_Issue #, if available:_
fixes https://github.com/style-dictionary/style-dictionary/issues/1316
partially addresses https://github.com/style-dictionary/style-dictionary/issues/1480 , once the example tokens there are fixed as well it could be closed.

_Description of changes:_

No longer complain about collisions when the values that collide are the same. In this case, the collision doesn't matter.
Fixes collision warnings for group level props like $type as well, assuming same value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
