### PR TITLE
fix: public docs to match the functionality & code's documentation

### DIFF
--- a/docs/src/content/docs/reference/Hooks/Transforms/predefined.mdx
+++ b/docs/src/content/docs/reference/Hooks/Transforms/predefined.mdx
@@ -304,7 +304,7 @@ Transforms the value into a scale-independent pixel (sp) value for font sizes on
 Transforms the value into a density-independent pixel (dp) value for non-font sizes on Android. It will not scale the number.
 
 ```js
-// Matches: token.type === 'fontSize'
+// Matches: token.type === 'dimension'
 // Returns:
 '10.0dp';
 ```


### PR DESCRIPTION
_Description of changes:_

Hi! Noticed that the public documentation has a typo / conflicting information. This patch fixes the public docs to match the [internal documentation](https://github.com/style-dictionary/style-dictionary/blob/main/lib/common/transforms.js#L707).

<img width="703" height="241" alt="Screenshot 2025-09-16 at 13 43 51" src="https://github.com/user-attachments/assets/fed3e8ba-d1a8-4f89-ab3b-feecd2240143" />

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

