### PR TITLE
feat: add size/compose/{dp, sp} to builtin transforms

### DIFF
--- a/.changeset/strong-impalas-enjoy.md
+++ b/.changeset/strong-impalas-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'style-dictionary': patch
+'style-dictionary': minor
 ---
 
 Add new size/compose/{sp,dp} transforms

--- a/.changeset/strong-impalas-enjoy.md
+++ b/.changeset/strong-impalas-enjoy.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Add new size/compose/{sp,dp} transforms

--- a/__integration__/__snapshots__/customFormats.test.snap.js
+++ b/__integration__/__snapshots__/customFormats.test.snap.js
@@ -867,6 +867,12 @@ snapshots["integration custom formats inline custom with new args should match s
         "size/compose/em": {
           "type": "value"
         },
+        "size/compose/sp": {
+          "type": "value"
+        },
+        "size/compose/dp": {
+          "type": "value"
+        },
         "size/swift/remToCGFloat": {
           "type": "value"
         },
@@ -1873,6 +1879,12 @@ snapshots["integration custom formats register custom format with new args shoul
           "type": "value"
         },
         "size/compose/em": {
+          "type": "value"
+        },
+        "size/compose/sp": {
+          "type": "value"
+        },
+        "size/compose/dp": {
           "type": "value"
         },
         "size/swift/remToCGFloat": {

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -45,6 +45,8 @@ const {
   sizeComposeRemToSp,
   sizeComposeEm,
   sizeComposeRemToDp,
+  sizeComposeDp,
+  sizeComposeSp,
   sizeSwiftRemToCGFloat,
   sizeRemToPx,
   sizePxToRem,
@@ -945,6 +947,54 @@ describe('common', () => {
       });
       it('should throw an error if prop value is Nan', () => {
         expect(() => transforms[sizeComposeRemToSp].transform({ value: 'a' }, {}, {})).to.throw();
+      });
+    });
+
+    describe(sizeComposeSp, () => {
+      it('should work', () => {
+        const value = transforms[sizeComposeSp].transform(
+          {
+            value: '12px',
+          },
+          {},
+          {},
+        );
+        const value2 = transforms[sizeComposeSp].transform(
+          {
+            value: '12',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('12.00.sp');
+        expect(value2).to.equal('12.00.sp');
+      });
+      it('should throw an error if prop value is Nan', () => {
+        expect(() => transforms[sizeComposeSp].transform({ value: 'a' }, {}, {})).to.throw();
+      });
+    });
+
+    describe(sizeComposeDp, () => {
+      it('should work', () => {
+        const value = transforms[sizeComposeDp].transform(
+          {
+            value: '12px',
+          },
+          {},
+          {},
+        );
+        const value2 = transforms[sizeComposeDp].transform(
+          {
+            value: '12',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('12.00.dp');
+        expect(value2).to.equal('12.00.dp');
+      });
+      it('should throw an error if prop value is Nan', () => {
+        expect(() => transforms[sizeComposeDp].transform({ value: 'a' })).to.throw();
       });
     });
 

--- a/docs/src/content/docs/reference/Hooks/Transforms/predefined.mdx
+++ b/docs/src/content/docs/reference/Hooks/Transforms/predefined.mdx
@@ -438,6 +438,30 @@ Adds the .em Compose extension to the end of a number. Does not scale the value
 
 ---
 
+### size/compose/sp
+
+Adds the .sp Compose extension to the end of a number. Does not scale the value
+
+```kotlin
+// Matches: token.type === 'fontSize'
+// Returns:
+"16.0.sp"
+```
+
+---
+
+### size/compose/dp
+
+Adds the .dp Compose extension to the end of a number. Does not scale the value
+
+```kotlin
+// Matches: token.type === 'dimension'
+// Returns:
+"16.0.dp"
+```
+
+---
+
 ### size/swift/remToCGFloat
 
 Scales the number by 16 (or the value of `basePxFontSize` on the platform in your config) to get to points for Swift and initializes a CGFloat

--- a/docs/src/content/docs/reference/enums.md
+++ b/docs/src/content/docs/reference/enums.md
@@ -256,8 +256,8 @@ export const transforms = {
   sizeComposeRemToSp: 'size/compose/remToSp',
   sizeComposeRemToDp: 'size/compose/remToDp',
   sizeComposeEm: 'size/compose/em',
-  sizeComposeDp: 'size/compose/dp'
-  sizeComposeSp: 'size/compose/sp'
+  sizeComposeDp: 'size/compose/dp',
+  sizeComposeSp: 'size/compose/sp',
   sizeSwiftRemToCGFloat: 'size/swift/remToCGFloat',
   sizeRemToPx: 'size/remToPx',
   sizePxToRem: 'size/pxToRem',

--- a/docs/src/content/docs/reference/enums.md
+++ b/docs/src/content/docs/reference/enums.md
@@ -256,6 +256,8 @@ export const transforms = {
   sizeComposeRemToSp: 'size/compose/remToSp',
   sizeComposeRemToDp: 'size/compose/remToDp',
   sizeComposeEm: 'size/compose/em',
+  sizeComposeDp: 'size/compose/dp'
+  sizeComposeSp: 'size/compose/sp'
   sizeSwiftRemToCGFloat: 'size/swift/remToCGFloat',
   sizeRemToPx: 'size/remToPx',
   sizePxToRem: 'size/pxToRem',

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -942,6 +942,50 @@ export default {
   },
 
   /**
+   * Adds the .sp Compose extension to the end of a number. Does not scale the value
+   *
+   * ```kotlin
+   * // Matches: token.type === 'fontSize'
+   * // Returns:
+   * "16.0.sp"
+   * ```
+   *
+   * @memberof Transforms
+   */
+  [transforms.sizeComposeSp]: {
+    type: value,
+    filter: isFontSize,
+    transform: function (token, _, options) {
+      const nonParsedVal = options.usesDtcg ? token.$value : token.value;
+      const val = parseFloat(nonParsedVal);
+      if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'sp');
+      return val.toFixed(2) + '.sp';
+    },
+  },
+
+  /**
+   * Adds the .dp Compose extension to the end of a number. Does not scale the value
+   *
+   * ```kotlin
+   * // Matches: token.type === 'dimension'
+   * // Returns:
+   * "16.0.dp"
+   * ```
+   *
+   * @memberof Transforms
+   */
+  [transforms.sizeComposeDp]: {
+    type: value,
+    filter: isDimension,
+    transform: function (token, _, options) {
+      const nonParsedVal = options.usesDtcg ? token.$value : token.value;
+      const val = parseFloat(nonParsedVal);
+      if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'dp');
+      return val.toFixed(2) + '.dp';
+    },
+  },
+
+  /**
    * Scales the number by 16 (or the value of 'basePxFontSize' on the platform in your config) to get to points for Swift and initializes a CGFloat
    *
    * ```js

--- a/lib/enums/transforms.js
+++ b/lib/enums/transforms.js
@@ -29,6 +29,8 @@ export const transforms = {
   sizeComposeRemToSp: /** @type {'size/compose/remToSp'} */ ('size/compose/remToSp'),
   sizeComposeRemToDp: /** @type {'size/compose/remToDp'} */ ('size/compose/remToDp'),
   sizeComposeEm: /** @type {'size/compose/em'} */ ('size/compose/em'),
+  sizeComposeSp: /** @type {'size/compose/sp'} */ ('size/compose/sp'),
+  sizeComposeDp: /** @type {'size/compose/dp'} */ ('size/compose/dp'),
   sizeSwiftRemToCGFloat: /** @type {'size/swift/remToCGFloat'} */ ('size/swift/remToCGFloat'),
   sizeRemToPx: /** @type {'size/remToPx'} */ ('size/remToPx'),
   sizePxToRem: /** @type {'size/pxToRem'} */ ('size/pxToRem'),


### PR DESCRIPTION
_Description of changes:_

Hello!

I’m currently building a cross-platform design system at work, and style-dictionary has been an absolute breeze to work with — thanks for that!

While working on this, I noticed there isn’t a built-in transform for `size/compose/{dp,sp}`. Of course, it’s easy to define a custom transform in your own Style Dictionary config, and I understand that [SD aims to stay minimal](https://github.com/style-dictionary/style-dictionary/blob/main/CONTRIBUTING.md#what-should-be-included:~:text=we%20don%27t%20want%20to%20be%20a%20swiss%20army%20knife%20that%20does%20everything%20out%20of%20the%20box).

That said, there are already built-in transforms for [size/compose/remToSp](https://styledictionary.com/reference/hooks/transforms/predefined/#sizecomposeremtosp) and [size/compose/remToDp](https://styledictionary.com/reference/hooks/transforms/predefined/#sizecomposeremtodp).
Since [size/sp](https://styledictionary.com/reference/hooks/transforms/predefined/#sizesp) and [size/dp](https://styledictionary.com/reference/hooks/transforms/predefined/#sizedp) don’t work directly on compose objects (especially when the object contains both dimensions and colors) as these transforms do not add the dot before the unit (i.e., `10.00dp` vs `10.00.dp`), I thought it would make sense to include size/compose/{dp,sp} as built-in transforms for consistency.

If these transforms are deemed unnecessary or if I've missed something relevant to the matter, feel free to close this PR. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
