### PR TITLE
fix: resolve references to tokens with 'value' in their name

### DIFF
--- a/.changeset/fix-value-in-token-names.md
+++ b/.changeset/fix-value-in-token-names.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix outputReferences for tokens with 'value' in their name. Previously, references to tokens like `object_type.value_chain` were incorrectly resolved because the code removed the first occurrence of `.value` instead of only the trailing suffix.

--- a/__tests__/common/formatHelpers/createPropertyFormatter.test.js
+++ b/__tests__/common/formatHelpers/createPropertyFormatter.test.js
@@ -563,6 +563,93 @@ describe('common', () => {
           await expect(cssRef).to.matchSnapshot();
         });
       });
+
+      describe('tokens with "value" in their name', () => {
+        const valueNameDictionary = {
+          object_type: {
+            value_chain: {
+              value: '10px',
+              original: {
+                value: '10px',
+                type: 'spacing',
+              },
+              name: 'object-type-value-chain',
+              path: ['object_type', 'value_chain'],
+              type: 'spacing',
+            },
+          },
+          reference: {
+            to_value_chain: {
+              value: '10px',
+              original: {
+                value: '{object_type.value_chain}',
+                type: 'spacing',
+              },
+              name: 'reference-to-value-chain',
+              path: ['reference', 'to_value_chain'],
+              type: 'spacing',
+            },
+          },
+        };
+
+        it('should support outputReferences for tokens with "value" in their name', () => {
+          const propFormatter = createPropertyFormatter({
+            outputReferences: true,
+            dictionary: { tokens: valueNameDictionary },
+            format: css,
+          });
+          expect(propFormatter(valueNameDictionary.object_type.value_chain)).to.equal(
+            '  --object-type-value-chain: 10px;',
+          );
+          expect(propFormatter(valueNameDictionary.reference.to_value_chain)).to.equal(
+            '  --reference-to-value-chain: var(--object-type-value-chain);',
+          );
+        });
+      });
+
+      describe('DTCG: tokens with "value" in their name', () => {
+        const dtcgValueNameDictionary = {
+          object_type: {
+            value_chain: {
+              $value: '10px',
+              original: {
+                $value: '10px',
+                $type: 'spacing',
+              },
+              name: 'object-type-value-chain',
+              path: ['object_type', 'value_chain'],
+              $type: 'spacing',
+            },
+          },
+          reference: {
+            to_value_chain: {
+              $value: '10px',
+              original: {
+                $value: '{object_type.value_chain}',
+                $type: 'spacing',
+              },
+              name: 'reference-to-value-chain',
+              path: ['reference', 'to_value_chain'],
+              $type: 'spacing',
+            },
+          },
+        };
+
+        it('should support DTCG outputReferences for tokens with "value" in their name', () => {
+          const propFormatter = createPropertyFormatter({
+            outputReferences: true,
+            dictionary: { tokens: dtcgValueNameDictionary },
+            format: css,
+            usesDtcg: true,
+          });
+          expect(propFormatter(dtcgValueNameDictionary.object_type.value_chain)).to.equal(
+            '  --object-type-value-chain: 10px;',
+          );
+          expect(propFormatter(dtcgValueNameDictionary.reference.to_value_chain)).to.equal(
+            '  --reference-to-value-chain: var(--object-type-value-chain);',
+          );
+        });
+      });
     });
   });
 });

--- a/__tests__/common/formatHelpers/sortByReference.test.js
+++ b/__tests__/common/formatHelpers/sortByReference.test.js
@@ -112,6 +112,90 @@ describe('common', () => {
           tokensWithUndefinedValue.color.primary,
         ]);
       });
+
+      describe('tokens with "value" in their name', () => {
+        const tokensWithValueInName = {
+          object_type: {
+            value_chain: {
+              value: '10px',
+              type: 'spacing',
+              original: {
+                value: '10px',
+                type: 'spacing',
+              },
+              name: 'object-type-value-chain',
+            },
+          },
+          reference: {
+            to_value_chain: {
+              value: '10px',
+              type: 'spacing',
+              original: {
+                value: '{object_type.value_chain}',
+                type: 'spacing',
+              },
+              name: 'reference-to-value-chain',
+            },
+          },
+        };
+
+        it('should correctly sort tokens with "value" in their name', () => {
+          const allTokens = [
+            tokensWithValueInName.reference.to_value_chain,
+            tokensWithValueInName.object_type.value_chain,
+          ];
+
+          const sorted = [...allTokens].sort(sortByReference(tokensWithValueInName));
+
+          expect(sorted).to.eql([
+            tokensWithValueInName.object_type.value_chain,
+            tokensWithValueInName.reference.to_value_chain,
+          ]);
+        });
+      });
+
+      describe('DTCG: tokens with "value" in their name', () => {
+        const dtcgTokensWithValueInName = {
+          object_type: {
+            value_chain: {
+              $value: '10px',
+              $type: 'spacing',
+              original: {
+                $value: '10px',
+                $type: 'spacing',
+              },
+              name: 'object-type-value-chain',
+            },
+          },
+          reference: {
+            to_value_chain: {
+              $value: '10px',
+              $type: 'spacing',
+              original: {
+                $value: '{object_type.value_chain}',
+                $type: 'spacing',
+              },
+              name: 'reference-to-value-chain',
+            },
+          },
+        };
+
+        it('should correctly sort DTCG tokens with "value" in their name', () => {
+          const allTokens = [
+            dtcgTokensWithValueInName.reference.to_value_chain,
+            dtcgTokensWithValueInName.object_type.value_chain,
+          ];
+
+          const sorted = [...allTokens].sort(
+            sortByReference(dtcgTokensWithValueInName, { usesDtcg: true }),
+          );
+
+          expect(sorted).to.eql([
+            dtcgTokensWithValueInName.object_type.value_chain,
+            dtcgTokensWithValueInName.reference.to_value_chain,
+          ]);
+        });
+      });
     });
   });
 });

--- a/__tests__/utils/reference/getReferences.test.js
+++ b/__tests__/utils/reference/getReferences.test.js
@@ -106,6 +106,70 @@ describe('utils', () => {
           { key: '{color.red}', ref: ['color', 'red'], value: '#f00' },
         ]);
       });
+
+      describe('tokens with "value" in their name', () => {
+        const tokensWithValueInName = {
+          object_type: {
+            value_chain: { value: '10px' },
+            another: { value: '20px' },
+          },
+          reference: {
+            to_value_chain: { value: '{object_type.value_chain}' },
+            to_value_chain_explicit: { value: '{object_type.value_chain.value}' },
+          },
+        };
+
+        it('should correctly resolve references to tokens with "value" in their name', () => {
+          expect(
+            getReferences(
+              tokensWithValueInName.reference.to_value_chain.value,
+              tokensWithValueInName,
+            ),
+          ).to.eql([{ ref: ['object_type', 'value_chain'], value: '10px' }]);
+        });
+
+        it('should correctly resolve explicit .value references to tokens with "value" in their name', () => {
+          expect(
+            getReferences(
+              tokensWithValueInName.reference.to_value_chain_explicit.value,
+              tokensWithValueInName,
+            ),
+          ).to.eql([{ ref: ['object_type', 'value_chain'], value: '10px' }]);
+        });
+      });
+
+      describe('DTCG: tokens with "value" in their name', () => {
+        const dtcgTokensWithValueInName = {
+          object_type: {
+            value_chain: { $value: '10px' },
+            another: { $value: '20px' },
+          },
+          reference: {
+            to_value_chain: { $value: '{object_type.value_chain}' },
+            to_value_chain_explicit: { $value: '{object_type.value_chain.$value}' },
+          },
+        };
+
+        it('should correctly resolve DTCG references to tokens with "value" in their name', () => {
+          expect(
+            getReferences(
+              dtcgTokensWithValueInName.reference.to_value_chain.$value,
+              dtcgTokensWithValueInName,
+              { usesDtcg: true },
+            ),
+          ).to.eql([{ ref: ['object_type', 'value_chain'], $value: '10px' }]);
+        });
+
+        it('should correctly resolve explicit .$value references to tokens with "value" in their name', () => {
+          expect(
+            getReferences(
+              dtcgTokensWithValueInName.reference.to_value_chain_explicit.$value,
+              dtcgTokensWithValueInName,
+              { usesDtcg: true },
+            ),
+          ).to.eql([{ ref: ['object_type', 'value_chain'], $value: '10px' }]);
+        });
+      });
     });
   });
 });

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -184,7 +184,7 @@ export default function createPropertyFormatter({
       const refs = getReferences(
         originalValue,
         tokens,
-        { unfilteredTokens, warnImmediately: false },
+        { unfilteredTokens, usesDtcg, warnImmediately: false },
         [],
       );
 

--- a/lib/common/formatHelpers/sortByReference.js
+++ b/lib/common/formatHelpers/sortByReference.js
@@ -49,10 +49,12 @@ export default function sortByReference(tokens, { unfilteredTokens, usesDtcg } =
       // Collect references for 'a' and 'b'
       const aRefs = getReferences(a.original[valueKey], tokens, {
         unfilteredTokens,
+        usesDtcg,
         warnImmediately: false,
       });
       const bRefs = getReferences(b.original[valueKey], tokens, {
         unfilteredTokens,
+        usesDtcg,
         warnImmediately: false,
       });
 

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -39,7 +39,8 @@ export function getReferences(value, tokens, opts = {}, references = []) {
    */
   function findReference(_, variable) {
     // remove 'value' to access the whole token object
-    variable = variable.trim().replace(`.${usesDtcg ? '$' : ''}value`, '');
+    const trailingValueRegex = usesDtcg ? /\.\$value$/ : /\.value$/;
+    variable = variable.trim().replace(trailingValueRegex, '');
 
     // Find what the value is referencing
     const pathName = getPathFromName(variable);


### PR DESCRIPTION
_Issue #, if available:_ #1563 

  _Description of changes:_

  Fixed bug in outputReferences when token name contains word 'value'.

  ## Problem
  Function `getReferences()` was using `.replace()` with string parameter.
  This removes first occurrence of `.value`, not the last one. Breaking tokens
   like:
  - Token name: `object_type.value_chain`
  - Reference: `{object_type.value_chain.value}`
  - Current behavior: resolves to `object_type_chain.value` (wrong)
  - Expected behavior: resolves to `object_type.value_chain` (correct)

  ## Solution
  Changed string replace to regex that matches only end of string:
  - **getReferences.js**: Use regex `/\.value$/` or `/\.\$value$/` to remove
  only trailing suffix
  - **createPropertyFormatter.js**: Pass `usesDtcg` flag to `getReferences()`
  (was missing)
  - **sortByReference.js**: Pass `usesDtcg` flag to `getReferences()` (was
  missing)
  - **Tests**: Added 8 test cases for tokens with 'value' in name

  ## Testing
  All tests passing. Added tests for both traditional and DTCG formats.

  Works correctly now for both token formats.

  By submitting this pull request, I confirm that my contribution is made
  under the terms of the Apache 2.0 license.