### PR TITLE
feat(hooks): add sort hook registration

### DIFF
--- a/__integration__/__snapshots__/customFormats.test.snap.js
+++ b/__integration__/__snapshots__/customFormats.test.snap.js
@@ -959,7 +959,8 @@ snapshots["integration custom formats inline custom with new args should match s
       "actions": {
         "android/copyImages": {},
         "copy_assets": {}
-      }
+      },
+      "sorts": {}
     },
     "source": [
       "__integration__/tokens/size/padding.json"
@@ -1973,7 +1974,8 @@ snapshots["integration custom formats register custom format with new args shoul
       "actions": {
         "android/copyImages": {},
         "copy_assets": {}
-      }
+      },
+      "sorts": {}
     },
     "source": [
       "__integration__/tokens/size/padding.json"

--- a/__tests__/common/formatHelpers/__snapshots__/formattedVariables.test.snap.js
+++ b/__tests__/common/formatHelpers/__snapshots__/formattedVariables.test.snap.js
@@ -26,3 +26,9 @@ snapshots["formatHelpers formattedVariables should output references when output
   --color-semantic-primary: var(--color-base-red-400);`;
 /* end snapshot formatHelpers formattedVariables should output references when outputReferences=true and match snapshot */
 
+snapshots["formatHelpers formattedVariables should use custom lineSeparator from formatting options"] = 
+`  --color-base-red-400: #EF5350;
+
+  --color-base-blue-500: #2196F3;`;
+/* end snapshot formatHelpers formattedVariables should use custom lineSeparator from formatting options */
+

--- a/__tests__/common/formatHelpers/formattedVariables.test.js
+++ b/__tests__/common/formatHelpers/formattedVariables.test.js
@@ -314,6 +314,33 @@ describe('formatHelpers', () => {
       expect(String(error)).to.include('Invalid "sort" option type');
     });
 
+    it('should throw when config hooks try to override the reserved built-in "name" sort', () => {
+      const dictionary = {
+        tokens,
+        allTokens: convertTokenData(tokens, { output: 'array' }),
+        unfilteredTokens: tokens,
+      };
+
+      let error;
+      try {
+        formattedVariables({
+          format: css,
+          dictionary,
+          sort: 'name',
+          hooks: {
+            sorts: {
+              name: (a, b) => b.name.localeCompare(a.name),
+            },
+          },
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error, 'Expected formattedVariables() to throw').to.exist;
+      expect(String(error)).to.include('"name" is a reserved built-in sort name');
+    });
+
     it('should use custom lineSeparator from formatting options', () => {
       const dictionary = {
         tokens,

--- a/__tests__/register/sort.test.js
+++ b/__tests__/register/sort.test.js
@@ -1,0 +1,136 @@
+import { expect } from 'chai';
+import StyleDictionary from '../../lib/StyleDictionary.js';
+import { registerSuite } from './register.suite.js';
+
+const configFoo = {
+  name: 'foo',
+  sort: (a, b) => a.name.localeCompare(b.name),
+};
+
+registerSuite({
+  config: configFoo,
+  registerMethod: 'registerSort',
+  prop: 'sorts',
+});
+
+describe('register', () => {
+  describe('sort', () => {
+    const StyleDictionaryExtended = new StyleDictionary({});
+
+    it('should error if name is not a string', () => {
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          sort: function () {},
+        });
+      }).to.throw("Can't register sort; sorts.name must be a string");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 1,
+          sort: function () {},
+        });
+      }).to.throw("Can't register sort; sorts.name must be a string");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: [],
+          sort: function () {},
+        });
+      }).to.throw("Can't register sort; sorts.name must be a string");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: {},
+          sort: function () {},
+        });
+      }).to.throw("Can't register sort; sorts.name must be a string");
+    });
+
+    it('should error if sort is not a function', () => {
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 'test',
+        });
+      }).to.throw("Can't register sort; sorts.sort must be a function");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 'test',
+          sort: 1,
+        });
+      }).to.throw("Can't register sort; sorts.sort must be a function");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 'test',
+          sort: 'name',
+        });
+      }).to.throw("Can't register sort; sorts.sort must be a function");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 'test',
+          sort: [],
+        });
+      }).to.throw("Can't register sort; sorts.sort must be a function");
+
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 'test',
+          sort: {},
+        });
+      }).to.throw("Can't register sort; sorts.sort must be a function");
+    });
+
+    it('should register a sort and make it available', () => {
+      const sort = {
+        name: 'test-sort',
+        sort: (a, b) => a.name.localeCompare(b.name),
+      };
+
+      StyleDictionaryExtended.registerSort(sort);
+
+      expect(StyleDictionaryExtended.hooks.sorts['test-sort']).to.equal(sort.sort);
+    });
+
+    it('should properly pass the registered sorter to instances', async () => {
+      const sort = {
+        name: 'test-sort-extend',
+        sort: (a, b) => a.name.localeCompare(b.name),
+      };
+
+      StyleDictionaryExtended.registerSort(sort);
+      const SDE2 = await StyleDictionaryExtended.extend({});
+      expect(SDE2.hooks.sorts['test-sort-extend']).to.equal(sort.sort);
+    });
+
+    it('should error when trying to register a sort with a reserved built-in name', () => {
+      expect(() => {
+        StyleDictionaryExtended.registerSort({
+          name: 'name',
+          sort: (a, b) => a.name.localeCompare(b.name),
+        });
+      }).to.throw('Can\'t register sort; "name" is a reserved built-in sort name');
+    });
+
+    it('should allow overwriting an already registered sort', () => {
+      const sort1 = {
+        name: 'test-overwrite',
+        sort: (a, b) => a.name.localeCompare(b.name),
+      };
+
+      const sort2 = {
+        name: 'test-overwrite',
+        sort: (a, b) => b.name.localeCompare(a.name), // reversed
+      };
+
+      StyleDictionaryExtended.registerSort(sort1);
+      expect(StyleDictionaryExtended.hooks.sorts['test-overwrite']).to.equal(sort1.sort);
+
+      // Overwrite with new sorter
+      StyleDictionaryExtended.registerSort(sort2);
+      expect(StyleDictionaryExtended.hooks.sorts['test-overwrite']).to.equal(sort2.sort);
+      expect(StyleDictionaryExtended.hooks.sorts['test-overwrite']).to.not.equal(sort1.sort);
+    });
+  });
+});

--- a/docs/src/content/docs/reference/Hooks/sorts.md
+++ b/docs/src/content/docs/reference/Hooks/sorts.md
@@ -1,0 +1,192 @@
+---
+title: Sorts
+---
+
+Sorts is a hook that provides a way to register custom sorting functions for tokens. These registered sorts can then be used by name in format options, particularly with the `formattedVariables` helper and formats that use it (like `css/variables`, `scss/variables`, `less/variables`, and `stylus/variables`).
+
+Common use cases for custom sorts are:
+
+- Sorting tokens by value type (colors, dimensions, etc.)
+- Sorting tokens by custom metadata or attributes
+- Creating reusable sorting logic that can be referenced by name
+
+---
+
+## Sort structure
+
+A sort is an object with two props:
+
+- `name`: the name of the sort
+- `sort`: a comparator function that receives two `TransformedToken` objects (`a` and `b`) and returns a number:
+  - Negative number if `a` should come before `b`
+  - Positive number if `a` should come after `b`
+  - `0` if they are equal
+
+The sort function follows the standard JavaScript `Array.sort` comparator pattern.
+
+```javascript title="my-sort.js"
+const mySort = {
+  name: 'by-value-type',
+  sort: (a, b) => {
+    // Sort by token type first
+    const typeCompare = (a.type || '').localeCompare(b.type || '');
+    if (typeCompare !== 0) return typeCompare;
+    // Then by name as tie-breaker
+    return a.name.localeCompare(b.name);
+  },
+};
+```
+
+---
+
+## Using sorts
+
+First you will need to tell Style Dictionary about your sort. You can do this in two ways:
+
+1. Using the [`.registerSort`](/reference/api#registersort) method
+1. Inline in the [configuration](/reference/config#properties) `hooks.sorts` property
+
+### .registerSort
+
+```javascript
+import StyleDictionary from 'style-dictionary';
+
+StyleDictionary.registerSort(mySort);
+```
+
+### Inline
+
+```javascript
+export default {
+  hooks: {
+    sorts: {
+      'by-value-type': mySort.sort,
+    },
+  },
+  // ... the rest of the configuration
+};
+```
+
+### Using it in format options
+
+Once registered, you can use the sort by name in format options:
+
+```json
+{
+  "source": ["**/*.tokens.json"],
+  "platforms": {
+    "css": {
+      "transformGroup": "css",
+      "files": [
+        {
+          "format": "css/variables",
+          "destination": "_variables.css",
+          "options": {
+            "sort": "by-value-type"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+You can also chain multiple sorts using an array:
+
+```json
+{
+  "options": {
+    "sort": ["by-value-type", "name"]
+  }
+}
+```
+
+When using `outputReferences: true`, reference-safe ordering is automatically enforced first, and your registered sorts act as tie-breakers.
+
+### Using in custom formats
+
+When creating custom formats that use the `formattedVariables` helper, you need to pass the `hooks` object to enable registered sorts:
+
+```javascript
+import { formattedVariables } from 'style-dictionary/utils';
+import { propertyFormatNames } from 'style-dictionary/enums';
+
+StyleDictionary.registerFormat({
+  name: 'myCustomFormat',
+  format: function ({ dictionary, options }) {
+    return formattedVariables({
+      format: propertyFormatNames.css,
+      dictionary,
+      sort: options.sort, // can be 'name', registered sort name, function, or array
+      hooks: options.hooks, // pass hooks to enable registered sorts
+    });
+  },
+});
+```
+
+Note: Unlike `filters` which are automatically resolved by Style Dictionary at the file level, `sorts` are resolved within format functions. The `options` object passed to format functions already contains the `hooks` object, so you can simply pass `options.hooks` to `formattedVariables`.
+
+---
+
+### Example
+
+~ sd-playground
+
+```json tokens
+{
+  "color": {
+    "red": {
+      "type": "color",
+      "value": "#ff0000"
+    },
+    "blue": {
+      "type": "color",
+      "value": "#0000ff"
+    }
+  },
+  "spacing": {
+    "small": {
+      "type": "dimension",
+      "value": "4px"
+    },
+    "large": {
+      "type": "dimension",
+      "value": "16px"
+    }
+  }
+}
+```
+
+```js config
+import { formats, transformGroups } from 'style-dictionary/enums';
+
+export default {
+  hooks: {
+    sorts: {
+      'by-type': (a, b) => {
+        // Sort by type first
+        const typeCompare = (a.type || '').localeCompare(b.type || '');
+        if (typeCompare !== 0) return typeCompare;
+        // Then by name
+        return a.name.localeCompare(b.name);
+      },
+    },
+  },
+  platforms: {
+    css: {
+      transformGroup: transformGroups.css,
+      files: [
+        {
+          format: formats.cssVariables,
+          destination: '_variables.css',
+          options: {
+            sort: 'by-type', // Uses the registered sort from hooks.sorts
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+Note: Built-in formats like `css/variables`, `scss/variables`, `less/variables`, and `stylus/variables` automatically pass `options.hooks` to `formattedVariables`, so registered sorts work without any additional configuration.

--- a/docs/src/content/docs/reference/Hooks/sorts.md
+++ b/docs/src/content/docs/reference/Hooks/sorts.md
@@ -22,6 +22,8 @@ A sort is an object with two props:
   - Positive number if `a` should come after `b`
   - `0` if they are equal
 
+The built-in sort name `name` is reserved and cannot be redefined in `registerSort()` or `hooks.sorts`.
+
 The sort function follows the standard JavaScript `Array.sort` comparator pattern.
 
 ```javascript title="my-sort.js"

--- a/docs/src/content/docs/reference/Utils/format-helpers.md
+++ b/docs/src/content/docs/reference/Utils/format-helpers.md
@@ -14,7 +14,7 @@ import { propertyFormatNames } from 'style-dictionary/enums';
 StyleDictionary.registerFormat({
   name: 'myCustomFormat',
   format: async ({ dictionary, file, options }) => {
-    const { outputReferences, sort } = options;
+    const { outputReferences, sort, hooks } = options;
     const header = await fileHeader({ file });
     return (
       header +
@@ -23,7 +23,8 @@ StyleDictionary.registerFormat({
         format: propertyFormatNames.css,
         dictionary,
         outputReferences,
-        sort, // 'name' | ['name'] | [customFn, 'name'] | (a, b) => number
+        sort, // 'name' | 'registered-sort-name' | [customFn, 'name'] | (a, b) => number
+        hooks, // pass hooks to enable registered sorts
       }) +
       '\n}\n'
     );
@@ -118,19 +119,20 @@ and not wanting to create redundant git diffs just because of the timestamp chan
 
 This is used to create lists of variables like Sass variables or CSS custom properties
 
-| Param                                 | Type                                  | Description                                                                                                                                                                                                    |
-| ------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `options`                             | `Object`                              |                                                                                                                                                                                                                |
-| `options.format`                      | `string`                              | What type of variables to output. Options are: `'css'`, `'sass'`, `'less'`, and `'stylus'`.                                                                                                                    |
-| `options.dictionary`                  | `Dictionary`                          | Transformed Dictionary object containing `allTokens`, `tokens` and `unfilteredTokens`.                                                                                                                         |
-| `options.dictionary.allTokens`        | `TransformedToken[]`                  | Flattened array of all tokens, easiest to loop over and export to a flat format.                                                                                                                               |
-| `options.dictionary.tokens`           | `TransformedTokens`                   | All tokens, still in unflattened object format.                                                                                                                                                                |
-| `options.dictionary.unfilteredTokens` | `TransformedTokens`                   | All tokens, still in unflattened object format, including tokens that were filtered out by filters.                                                                                                            |
-| `options.outputReferences`            | `boolean \| OutputReferencesFunction` | Whether or not to output references. You will want to pass this from the `options` object sent to the format function. Also allows passing a function to conditionally output references on a per token basis. |
-| `options.formatting`                  | `Object`                              | Custom formatting properties that define parts of a comment in code. The configurable strings are: `prefix`, `lineSeparator`, `header`, and `footer`.                                                          |
-| `options.themeable`                   | `boolean`                             | Whether tokens should default to being themeable. Defaults to `false`.                                                                                                                                         |
-| `options.usesDtcg`                    | `boolean`                             | Whether tokens use the DTCG standard. Defaults to `false`                                                                                                                                                      |
-| `options.sort`                        | `SortOption`                          | Optional sorting strategy. Use `'name'` to sort alphabetically by token name or a custom comparator function `(a: Token, b: Token) => -1                                                                       | 1   | 0`. You can chain multiple sorters with an array of sorters (e.g., `[customFn, 'name']`). When `outputReferences`is`true`, reference-safe ordering is automatically enforced first, and your sort acts as a tie-breaker. Defaults to no sorting. |
+| Param                                 | Type                                  | Description                                                                                                                                                                                                          |
+| ------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `options`                             | `Object`                              |                                                                                                                                                                                                                      |
+| `options.format`                      | `string`                              | What type of variables to output. Options are: `'css'`, `'sass'`, `'less'`, and `'stylus'`.                                                                                                                          |
+| `options.dictionary`                  | `Dictionary`                          | Transformed Dictionary object containing `allTokens`, `tokens` and `unfilteredTokens`.                                                                                                                               |
+| `options.dictionary.allTokens`        | `TransformedToken[]`                  | Flattened array of all tokens, easiest to loop over and export to a flat format.                                                                                                                                     |
+| `options.dictionary.tokens`           | `TransformedTokens`                   | All tokens, still in unflattened object format.                                                                                                                                                                      |
+| `options.dictionary.unfilteredTokens` | `TransformedTokens`                   | All tokens, still in unflattened object format, including tokens that were filtered out by filters.                                                                                                                  |
+| `options.outputReferences`            | `boolean \| OutputReferencesFunction` | Whether or not to output references. You will want to pass this from the `options` object sent to the format function. Also allows passing a function to conditionally output references on a per token basis.       |
+| `options.formatting`                  | `Object`                              | Custom formatting properties that define parts of a comment in code. The configurable strings are: `prefix`, `lineSeparator`, `header`, and `footer`.                                                                |
+| `options.themeable`                   | `boolean`                             | Whether tokens should default to being themeable. Defaults to `false`.                                                                                                                                               |
+| `options.usesDtcg`                    | `boolean`                             | Whether tokens use the DTCG standard. Defaults to `false`                                                                                                                                                            |
+| `options.sort`                        | `SortOption`                          | Optional sorting strategy. Use `'name'` to sort alphabetically by token name or a custom comparator function `(a: Token, b: Token) => -1                                                                             | 1   | 0`. You can chain multiple sorters with an array of sorters (e.g., `[customFn, 'name']`). When `outputReferences`is`true`, reference-safe ordering is automatically enforced first, and your sort acts as a tie-breaker. Defaults to no sorting. |
+| `options.hooks`                       | `Hooks`                               | Hooks object containing registered sorts. Pass `options.hooks` from the format function to enable registered sorts. Style Dictionary automatically provides this in the `options` object passed to format functions. |
 
 Example:
 
@@ -145,9 +147,51 @@ StyleDictionary.registerFormat({
       dictionary,
       outputReferences: options.outputReferences,
       sort: options.sort,
+      hooks: options.hooks, // pass hooks to enable registered sorts
     });
   },
 });
+```
+
+Using a registered sort:
+
+When you have registered a sort (either via `StyleDictionary.registerSort()` or in your config's `hooks.sorts`), you can use it by name in `formattedVariables`:
+
+```js title="build-tokens.js"
+import { formattedVariables } from 'style-dictionary/utils';
+import { propertyFormatNames } from 'style-dictionary/enums';
+
+StyleDictionary.registerFormat({
+  name: 'myCustomFormat',
+  format: function ({ dictionary, options }) {
+    // The sort name (e.g., 'by-type') comes from options.sort
+    // The sort must be registered in hooks.sorts
+    // (either via registerSort() or in config)
+    return formattedVariables({
+      format: propertyFormatNames.css,
+      dictionary,
+      sort: options.sort, // Can be 'name', registered sort name, function, or array
+      hooks: options.hooks, // pass hooks to enable registered sorts
+    });
+  },
+});
+```
+
+The sort can be registered in your config file, and then used via `options.sort`:
+
+```js title="sd.config.js"
+export default {
+  hooks: {
+    sorts: {
+      'by-type': (a, b) => {
+        const typeCompare = (a.type || '').localeCompare(b.type || '');
+        if (typeCompare !== 0) return typeCompare;
+        return a.name.localeCompare(b.name);
+      },
+    },
+  },
+  // ... rest of config
+};
 ```
 
 ---

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -494,6 +494,33 @@ StyleDictionary.registerFilter({
 
 ---
 
+### registerSort
+
+> `StyleDictionary.registerSort(sort) ⇒ StyleDictionary`
+
+Add a custom [sort](/reference/hooks/sorts) to the Style Dictionary.
+
+| Param     | Type       | Description                                                                                                                     |
+| --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Sort      | `Object`   |                                                                                                                                 |
+| Sort.name | `string`   | Name of the sort to be referenced in format options                                                                             |
+| Sort.sort | `function` | Comparator function that takes two tokens and returns a number. Follows the standard JavaScript `Array.sort` comparator pattern |
+
+Example:
+
+```js
+StyleDictionary.registerSort({
+  name: 'by-type',
+  sort: (a, b) => {
+    const typeCompare = (a.type || '').localeCompare(b.type || '');
+    if (typeCompare !== 0) return typeCompare;
+    return a.name.localeCompare(b.name);
+  },
+});
+```
+
+---
+
 ### registerFormat
 
 > `StyleDictionary.registerFormat(format) ⇒ StyleDictionary`

--- a/docs/starlight-config.ts
+++ b/docs/starlight-config.ts
@@ -130,6 +130,7 @@ export default {
               ],
             },
             { label: 'Filters', link: '/reference/hooks/filters' },
+            { label: 'Sorts', link: '/reference/hooks/sorts' },
             { label: 'File Headers', link: '/reference/hooks/file-headers' },
             { label: 'Actions', link: '/reference/hooks/actions' },
           ],

--- a/lib/Register.js
+++ b/lib/Register.js
@@ -3,6 +3,7 @@ import transformGroupBuiltins from './common/transformGroups.js';
 import formatBuiltins from './common/formats.js';
 import actionBuiltins from './common/actions.js';
 import filterBuiltins from './common/filters.js';
+import sortBuiltins from './common/sort.js';
 import { deepmerge } from './utils/deepmerge.js';
 import { transformTypes } from './enums/index.js';
 
@@ -14,6 +15,7 @@ import { transformTypes } from './enums/index.js';
  * @typedef {import('../types/Filter.d.ts').Filter} Filter
  * @typedef {import('../types/Format.d.ts').Format} Format
  * @typedef {import('../types/Action.d.ts').Action} Action
+ * @typedef {import('../types/Sort.d.ts').Sort} Sort
  * @typedef {import('../types/Config.d.ts').Hooks} Hooks
  */
 
@@ -41,6 +43,9 @@ function getBuiltinHooks() {
     },
     actions: {
       ...actionBuiltins,
+    },
+    sorts: {
+      ...sortBuiltins,
     },
   };
 }
@@ -396,6 +401,53 @@ export class Register {
     target.hooks = deepmerge(target.hooks, {
       fileHeaders: {
         [name]: fileHeader,
+      },
+    });
+    return target;
+  }
+
+  /**
+   * @param {Sort} cfg
+   */
+  static registerSort(cfg) {
+    // this = class
+    this.__registerSort(cfg, this);
+  }
+
+  /**
+   * @param {Sort} cfg
+   */
+  registerSort(cfg) {
+    // this = instance
+    /** @type {typeof Register} */ (this.constructor).__registerSort(cfg, this);
+  }
+
+  /**
+   * @param {Sort} sort
+   * @param {typeof Register | Register} target
+   */
+  static __registerSort(sort, target) {
+    const { name, sort: sortFn } = sort;
+    if (typeof name !== 'string')
+      throw new Error("Can't register sort; sorts.name must be a string");
+    if (typeof sortFn !== 'function')
+      throw new Error("Can't register sort; sorts.sort must be a function");
+
+    // Prevent overriding built-in 'name' sort
+    // 'name' is hardcoded in formattedVariables.js, so it cannot be overridden
+    if (name === 'name') {
+      throw new Error(
+        `Can't register sort; "name" is a reserved built-in sort name. ` +
+          `Please choose a different name.`,
+      );
+    }
+
+    this.deleteExistingHook(target, 'sorts', name);
+
+    // make sure to trigger the setter
+    target.hooks = deepmerge(target.hooks, {
+      sorts: {
+        [name]: sortFn,
       },
     });
     return target;

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -10,6 +10,7 @@ import sortByName from './sortByName.js';
  * @typedef {import('../../../types/Sort.d.ts').SortFn} SortFn
  * @typedef {import('../../../types/Sort.d.ts').SortOption} SortOption
  * @typedef {import('../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../types/Config.d.ts').Hooks} Hooks
  */
 
 const defaultFormatting = {
@@ -30,7 +31,8 @@ const defaultFormatting = {
  * @param {Boolean} [options.themeable] [false] - Whether tokens should default to being themeable.
  * @param {boolean} [options.usesDtcg] [false] - Whether DTCG token syntax should be uses.
  * @param {SortOption} [options.sort] - Optional sorting strategy.
- * @returns {String}
+ * @param {Hooks} [options.hooks] - Hooks object containing registered sorts.
+ * @returns {string}
  * @example
  * ```js
  * import { propertyFormatNames } from 'style-dictionary/enums';
@@ -41,7 +43,9 @@ const defaultFormatting = {
  *     return formattedVariables({
  *       format: propertyFormatNames.less,
  *       dictionary,
- *       outputReferences: options.outputReferences
+ *       outputReferences: options.outputReferences,
+ *       sort: options.sort, // optional: 'name', registered sort name, comparator function, or array
+ *       hooks: options.hooks, // pass hooks to enable registered sort
  *     });
  *   }
  * });
@@ -56,6 +60,7 @@ export default function formattedVariables({
   themeable = false,
   usesDtcg = false,
   sort,
+  hooks,
 }) {
   // typecast, we know that by know the tokens have been transformed
   let allTokens = /** @type {Token[]} */ (dictionary.allTokens);
@@ -66,7 +71,7 @@ export default function formattedVariables({
 
   const sortInputs = sort ? (Array.isArray(sort) ? sort : [sort]) : [];
 
-  // reference-safety sorter is an internal concern:
+  // reference-safety sort is an internal concern:
   // we only compute it when outputReferences=true
   const byReference = outputReferences
     ? sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens, usesDtcg })
@@ -74,30 +79,37 @@ export default function formattedVariables({
 
   /**
    * @param {SortFn} keyOrFn
-   * @returns {((a: Token, b: Token) => number) | null}
+   * @returns {SortFn | null}
    */
   const normalize = (keyOrFn) => {
     if (typeof keyOrFn === 'function') return keyOrFn;
 
+    // Built-in 'name' sort takes priority over any registered sort with the same name
     if (keyOrFn === 'name') return sortByName;
 
-    // Fail loudly for invalid values (esp. typos)
+    // Check if it's a registered sort hook
     if (typeof keyOrFn === 'string') {
+      const registeredSorter = hooks?.sorts?.[keyOrFn];
+      if (registeredSorter) {
+        return registeredSorter;
+      }
+
+      // Fail loudly for invalid values (esp. typos)
       throw new Error(
         `Invalid "sort" option: "${keyOrFn}". ` +
-          `Use "name", a comparator function, or an array of those.`,
+          `Use "name", a registered sort name, a comparator function, or an array of those.`,
       );
     }
 
     // Non-string non-function values are also invalid
     throw new Error(
       `Invalid "sort" option type: ${typeof keyOrFn}. ` +
-        `Use "name", a comparator function, or an array of those.`,
+        `Use "name", a registered sort name, a comparator function, or an array of those.`,
     );
   };
 
   /**
-   * @param {((a: Token, b: Token) => number) | null} s
+   * @param {SortFn | null} s
    * @returns {s is ((a: Token, b: Token) => number)}
    */
   const isComparator = (s) => s !== null;

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -77,6 +77,13 @@ export default function formattedVariables({
     ? sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens, usesDtcg })
     : null;
 
+  if (hooks?.sorts?.name && hooks.sorts.name !== sortByName) {
+    throw new Error(
+      `Can't register sort; "name" is a reserved built-in sort name. ` +
+        `Please choose a different name.`,
+    );
+  }
+
   /**
    * @param {SortFn} keyOrFn
    * @returns {SortFn | null}

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -193,7 +193,8 @@ const formats = {
       : options.selector
         ? [options.selector]
         : [`:root`];
-    const { outputReferences, outputReferenceFallbacks, usesDtcg, formatting, sort } = options;
+    const { outputReferences, outputReferenceFallbacks, usesDtcg, formatting, sort, hooks } =
+      options;
     const header = await fileHeader({
       file,
       formatting: getFormattingCloneWithoutPrefix(formatting),
@@ -220,6 +221,7 @@ const formats = {
       },
       usesDtcg,
       sort,
+      hooks,
     });
 
     return (
@@ -290,7 +292,7 @@ const formats = {
    */
   [scssMapDeep]: async function ({ dictionary, options, file }) {
     // Default the "themeable" option to true for backward compatibility.
-    const { outputReferences, themeable = true, formatting, usesDtcg, sort } = options;
+    const { outputReferences, themeable = true, formatting, usesDtcg, sort, hooks } = options;
     const header = await fileHeader({
       file,
       commentStyle: long,
@@ -308,6 +310,7 @@ const formats = {
         formatting,
         usesDtcg,
         sort,
+        hooks,
       }) +
       '\n' +
       scssMapDeepTemplate({ dictionary, options })
@@ -328,7 +331,7 @@ const formats = {
    * ```
    */
   [scssVariables]: async function ({ dictionary, options, file }) {
-    const { outputReferences, themeable = false, formatting, usesDtcg, sort } = options;
+    const { outputReferences, themeable = false, formatting, usesDtcg, sort, hooks } = options;
     const header = await fileHeader({
       file,
       commentStyle: short,
@@ -345,6 +348,7 @@ const formats = {
         formatting,
         usesDtcg,
         sort,
+        hooks,
       }) +
       '\n'
     );
@@ -384,7 +388,7 @@ const formats = {
    * ```
    */
   [lessVariables]: async function ({ dictionary, options, file }) {
-    const { outputReferences, formatting, usesDtcg, sort } = options;
+    const { outputReferences, formatting, usesDtcg, sort, hooks } = options;
     const header = await fileHeader({
       file,
       commentStyle: short,
@@ -400,6 +404,7 @@ const formats = {
         formatting,
         usesDtcg,
         sort,
+        hooks,
       }) +
       '\n'
     );
@@ -439,7 +444,7 @@ const formats = {
    * ```
    */
   [stylusVariables]: async function ({ dictionary, options, file, platform }) {
-    const { formatting, usesDtcg, sort } = options;
+    const { formatting, usesDtcg, sort, hooks } = options;
     const outputReferences = !!platform.options?.outputReferences;
     const header = await fileHeader({
       file,
@@ -456,6 +461,7 @@ const formats = {
         formatting,
         usesDtcg,
         sort,
+        hooks,
       }) +
       '\n'
     );

--- a/lib/common/sort.js
+++ b/lib/common/sort.js
@@ -1,0 +1,19 @@
+import sortByName from './formatHelpers/sortByName.js';
+
+/**
+ * @typedef {import('../../types/Sort.d.ts').Sort} Sort
+ */
+
+/**
+ * Built-in sorts available for use in format options
+ * @namespace Sorts
+ */
+
+/** @type {Record<string, Sort['sort']>} */
+export default {
+  /**
+   * Sort tokens alphabetically by name
+   * @memberof Sorts
+   */
+  name: sortByName,
+};

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -7,6 +7,7 @@ import type { Transform } from './Transform.js';
 import type { Format, OutputReferences } from './Format.js';
 import type { SortOption } from './Sort.js';
 import type { Action } from './Action.js';
+import type { Sort } from './Sort.js';
 import {
   logBrokenReferenceLevels,
   logWarningLevels,
@@ -26,6 +27,7 @@ export interface Hooks {
   fileHeaders?: Record<string, FileHeader>;
   filters?: Record<string, Filter['filter']>;
   actions?: Record<string, Omit<Action, 'name'>>;
+  sorts?: Record<string, Sort['sort']>;
 }
 
 // contains a few typed props of options that are commonly reused between multiple formats

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -5,9 +5,8 @@ import type { Parser } from './Parser.js';
 import type { Preprocessor } from './Preprocessor.js';
 import type { Transform } from './Transform.js';
 import type { Format, OutputReferences } from './Format.js';
-import type { SortOption } from './Sort.js';
+import type { SortComparator, SortOption } from './Sort.js';
 import type { Action } from './Action.js';
-import type { Sort } from './Sort.js';
 import {
   logBrokenReferenceLevels,
   logWarningLevels,
@@ -27,7 +26,7 @@ export interface Hooks {
   fileHeaders?: Record<string, FileHeader>;
   filters?: Record<string, Filter['filter']>;
   actions?: Record<string, Omit<Action, 'name'>>;
-  sorts?: Record<string, Sort['sort']>;
+  sorts?: Record<string, SortComparator>;
 }
 
 // contains a few typed props of options that are commonly reused between multiple formats

--- a/types/Sort.ts
+++ b/types/Sort.ts
@@ -3,17 +3,18 @@ import { builtInSorts } from '../lib/enums/sorts.js';
 
 export type BuiltInSorts = typeof builtInSorts;
 
-// register by name, to be implemented
+export type SortComparator = (a: TransformedToken, b: TransformedToken) => number;
+
 export interface Sort {
   name: string;
-  sort: SortFn;
+  sort: SortComparator;
 }
 
 /**
  * A single sort function - either a built-in sort referenced by name string or a custom comparator function
  * for inline usage
  */
-export type SortFn = string | ((a: TransformedToken, b: TransformedToken) => number);
+export type SortFn = string | SortComparator;
 
 /**
  * Sort option for formattedVariables - can be a single sort item or an array of sort items

--- a/types/index.ts
+++ b/types/index.ts
@@ -26,7 +26,7 @@ export type { Filter } from './Filter.js';
 
 export type { Format, FormatFnArguments, FormatFn, OutputReferences } from './Format.js';
 
-export type { SortOption, SortFn, BuiltInSorts } from './Sort.js';
+export type { Sort, SortOption, SortFn, SortComparator, BuiltInSorts } from './Sort.js';
 
 export type { Parser, ParserOptions } from './Parser.js';
 


### PR DESCRIPTION
Follow-up work for #1611 .

## Description

This PR introduces **sort hook registration** to Style Dictionary, enabling users to register custom sorting functions by name and reuse them across multiple format configurations. This provides a more maintainable, reusable alternative to inline comparator functions when sorting tokens.

### Changes
- **Sort Hook Registration (new feature)**: Added `registerSort()` to register custom sort functions by name, following existing hook patterns (`registerTransform`, `registerFilter`, etc.).
- **formattedVariables Integration**: Updated `formattedVariables` to accept registered sort names in addition to inline comparator functions and the built-in `'name'` sort.
- **Type Safety**: Added TypeScript types for sort hooks in `Config.ts` to ensure type safety when using registered sorts.
- **Documentation**: Added comprehensive documentation for the sort hook system, including usage examples and recommended patterns.
- **Testing**: Added full test coverage for sort registration (validation, instance vs class registration, and error handling).

## Motivation

- **Reusability**: Previously, custom sorting logic had to be duplicated inline per format configuration. Registered sorts allow defining logic once and referencing it by name across formats/platforms.
- **Maintainability**: Centralized sort definitions make it easy to update sorting behavior without touching multiple config blocks.
- **Consistency**: Matches existing Style Dictionary hook APIs, creating a more uniform developer experience.
- **Developer Experience**: Descriptive errors for invalid sort names help catch typos and misconfigurations early.

## Breaking Changes

None. This is a purely additive change and remains backward compatible with:
- Existing inline comparator functions
- The built-in `'name'` sort