### PR TITLE
feat(utils): add stable applyReferenceSafeOrdering for reference-safe token ordering

### DIFF
--- a/__tests__/common/formatHelpers/applyReferenceSafeOrdering.test.js
+++ b/__tests__/common/formatHelpers/applyReferenceSafeOrdering.test.js
@@ -1,0 +1,240 @@
+import { expect } from 'chai';
+import applyReferenceSafeOrdering from '../../../lib/common/formatHelpers/applyReferenceSafeOrdering.js';
+
+const createToken = (name, value, originalValue, usesDtcg = false) => {
+  const valueKey = usesDtcg ? '$value' : 'value';
+  return {
+    name,
+    [valueKey]: value,
+    original: { [valueKey]: originalValue },
+    path: name.split('-'),
+  };
+};
+
+describe('common', () => {
+  describe('formatHelpers', () => {
+    describe('applyReferenceSafeOrdering', () => {
+      it('should preserve order when no references exist', () => {
+        const tokenA = createToken('token-a', '#000', '#000');
+        const tokenB = createToken('token-b', '#111', '#111');
+        const tokenC = createToken('token-c', '#222', '#222');
+        const tokenD = createToken('token-d', '#333', '#333');
+
+        const sortedTokens = [tokenC, tokenD, tokenA, tokenB];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'token-c': tokenC,
+          'token-d': tokenD,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result).to.eql(sortedTokens);
+      });
+
+      it('should reorder to satisfy direct reference dependencies', () => {
+        const tokenB = createToken('token-b', '#111', '#111');
+        const tokenA = createToken('token-a', '#111', '{token-b.value}');
+
+        const sortedTokens = [tokenA, tokenB];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result).to.eql([tokenB, tokenA]);
+        expect(result.indexOf(tokenB)).to.be.lessThan(result.indexOf(tokenA));
+      });
+
+      it('should handle transitive dependencies (A -> B -> C)', () => {
+        const tokenC = createToken('token-c', '#222', '#222');
+        const tokenB = createToken('token-b', '#222', '{token-c.value}');
+        const tokenA = createToken('token-a', '#222', '{token-b.value}');
+
+        const sortedTokens = [tokenA, tokenB, tokenC];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'token-c': tokenC,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result).to.eql([tokenC, tokenB, tokenA]);
+        expect(result.indexOf(tokenC)).to.be.lessThan(result.indexOf(tokenB));
+        expect(result.indexOf(tokenB)).to.be.lessThan(result.indexOf(tokenA));
+      });
+
+      it('should preserve order when user-sorted order is (c,d,a,b) but references require minimal movement', () => {
+        const tokenB = createToken('token-b', '#111', '#111');
+        const tokenA = createToken('token-a', '#111', '{token-b.value}');
+        const tokenC = createToken('token-c', '#222', '#222');
+        const tokenD = createToken('token-d', '#333', '#333');
+
+        const sortedTokens = [tokenC, tokenD, tokenA, tokenB];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'token-c': tokenC,
+          'token-d': tokenD,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result.indexOf(tokenB)).to.be.lessThan(result.indexOf(tokenA));
+        expect(result.indexOf(tokenC)).to.be.lessThan(result.indexOf(tokenD));
+
+        const cIdx = result.indexOf(tokenC);
+        const dIdx = result.indexOf(tokenD);
+        expect(cIdx).to.be.lessThan(dIdx);
+      });
+
+      it('should preserve relative order of independent tokens', () => {
+        const tokenB = createToken('token-b', '#111', '#111');
+        const tokenA = createToken('token-a', '#111', '{token-b.value}');
+        const tokenC = createToken('token-c', '#222', '#222');
+        const tokenD = createToken('token-d', '#333', '#333');
+
+        const sortedTokens = [tokenC, tokenD, tokenA, tokenB];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'token-c': tokenC,
+          'token-d': tokenD,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result.indexOf(tokenC)).to.be.lessThan(result.indexOf(tokenD));
+        expect(result.indexOf(tokenB)).to.be.lessThan(result.indexOf(tokenA));
+      });
+
+      it('should ignore references to tokens not in sortedTokens', () => {
+        const tokenA = createToken('token-a', '#111', '{external-token.value}');
+        const tokenB = createToken('token-b', '#222', '#222');
+
+        const sortedTokens = [tokenA, tokenB];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'external-token': createToken('external-token', '#000', '#000'),
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens, {
+          unfilteredTokens: tokens,
+        });
+
+        expect(result).to.eql([tokenA, tokenB]);
+      });
+
+      it('should handle cycles deterministically by keeping original order', () => {
+        const tokenA = createToken('token-a', '#111', '{token-b.value}');
+        const tokenB = createToken('token-b', '#111', '{token-a.value}');
+
+        const sortedTokens = [tokenA, tokenB];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result.length).to.equal(2);
+        expect(result).to.include(tokenA);
+        expect(result).to.include(tokenB);
+        expect(result).to.eql([tokenA, tokenB]);
+      });
+
+      it('should handle empty array', () => {
+        const result = applyReferenceSafeOrdering([], {});
+        expect(result).to.eql([]);
+      });
+
+      it('should handle tokens with multiple references', () => {
+        const tokenB = createToken('token-b', '#111', '#111');
+        const tokenC = createToken('token-c', '#222', '#222');
+        const tokenA = createToken('token-a', '#111 #222', '{token-b.value} {token-c.value}');
+
+        const sortedTokens = [tokenA, tokenB, tokenC];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'token-c': tokenC,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result.indexOf(tokenB)).to.be.lessThan(result.indexOf(tokenA));
+        expect(result.indexOf(tokenC)).to.be.lessThan(result.indexOf(tokenA));
+      });
+
+      [
+        ['default', false],
+        ['dtcg', true],
+      ].forEach(([tokenFormat, usesDtcg]) => {
+        it(`should work with ${tokenFormat} format (usesDtcg=${usesDtcg})`, () => {
+          const refKey = usesDtcg ? '$value' : 'value';
+          const tokenB = createToken('token-b', '#111', '#111', usesDtcg);
+          const tokenA = createToken('token-a', '#111', `{token-b.${refKey}}`, usesDtcg);
+
+          const sortedTokens = [tokenA, tokenB];
+          const tokens = {
+            'token-a': tokenA,
+            'token-b': tokenB,
+          };
+
+          const result = applyReferenceSafeOrdering(sortedTokens, tokens, { usesDtcg });
+
+          expect(result).to.eql([tokenB, tokenA]);
+        });
+      });
+
+      it('should preserve stability: when multiple tokens are available, choose earliest in original order', () => {
+        const tokenB = createToken('token-b', '#111', '#111');
+        const tokenA = createToken('token-a', '#111', '{token-b.value}');
+        const tokenC = createToken('token-c', '#222', '#222');
+        const tokenD = createToken('token-d', '#333', '#333');
+
+        const sortedTokens = [tokenC, tokenD, tokenB, tokenA];
+        const tokens = {
+          'token-a': tokenA,
+          'token-b': tokenB,
+          'token-c': tokenC,
+          'token-d': tokenD,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result[0]).to.equal(tokenC);
+        expect(result[1]).to.equal(tokenD);
+        expect(result[2]).to.equal(tokenB);
+        expect(result[3]).to.equal(tokenA);
+      });
+
+      it('should handle complex scenario: 2 base tokens and 2 referencing tokens', () => {
+        const base1 = createToken('base-1', '#111', '#111');
+        const base2 = createToken('base-2', '#222', '#222');
+        const ref1 = createToken('ref-1', '#111', '{base-1.value}');
+        const ref2 = createToken('ref-2', '#222', '{base-2.value}');
+
+        const sortedTokens = [ref1, ref2, base1, base2];
+        const tokens = {
+          'base-1': base1,
+          'base-2': base2,
+          'ref-1': ref1,
+          'ref-2': ref2,
+        };
+
+        const result = applyReferenceSafeOrdering(sortedTokens, tokens);
+
+        expect(result.indexOf(base1)).to.be.lessThan(result.indexOf(ref1));
+        expect(result.indexOf(base2)).to.be.lessThan(result.indexOf(ref2));
+        expect(result.indexOf(base1)).to.be.lessThan(result.indexOf(base2));
+        expect(result.indexOf(ref1)).to.be.lessThan(result.indexOf(ref2));
+      });
+    });
+  });
+});

--- a/lib/common/formatHelpers/applyReferenceSafeOrdering.js
+++ b/lib/common/formatHelpers/applyReferenceSafeOrdering.js
@@ -108,7 +108,7 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
 
   // Priority queue: tokens with no remaining dependencies, ordered by original index
   // We use an array and sort it by originalIndex to maintain stability
-  const available = [];
+  const available = /** @type {string[]} */ ([]);
   for (const token of sortedTokens) {
     if (!token || !token.name) continue;
     if (inDegree.get(token.name) === 0) {
@@ -122,10 +122,25 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
   const result = [];
   const processed = new Set();
 
+  let head = 0;
+
+  // Sort only the active segment (head..end) to avoid breaking the head pointer semantics.
+  function sortAvailableActive() {
+    const activeLen = available.length - head;
+    if (activeLen <= 1) return;
+
+    const active = available.slice(head);
+    active.sort((a, b) => originalIndex.get(a) - originalIndex.get(b));
+
+    // Keep consumed prefix intact; replace only the active part.
+    available.length = head;
+    available.push(...active);
+  }
+
   // Process tokens in topological order
   // Continue until all tokens are processed, even if available queue is empty (handles cycles)
   while (processed.size < tokenMap.size) {
-    let tokenName = available.shift();
+    let tokenName = head < available.length ? available[head++] : undefined;
 
     // If no available tokens but unprocessed remain, pick earliest unprocessed token
     // This handles cycles and ensures all tokens are processed
@@ -148,6 +163,7 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
 
     // Decrease in-degree for all dependents
     const tokenDependents = dependents.get(tokenName);
+    let didEnqueue = false;
     if (tokenDependents) {
       for (const dependentName of tokenDependents) {
         const currentInDegree = inDegree.get(dependentName);
@@ -158,14 +174,15 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
           // If this dependent now has no remaining dependencies, add it to available
           if (newInDegree === 0) {
             available.push(dependentName);
+            didEnqueue = true;
           }
         }
       }
     }
 
     // Re-sort to maintain stability (only when multiple items to avoid unnecessary sorting)
-    if (available.length > 1) {
-      available.sort((a, b) => originalIndex.get(a) - originalIndex.get(b));
+    if (didEnqueue && available.length - head > 1) {
+      sortAvailableActive();
     }
   }
 

--- a/lib/common/formatHelpers/applyReferenceSafeOrdering.js
+++ b/lib/common/formatHelpers/applyReferenceSafeOrdering.js
@@ -1,0 +1,173 @@
+import usesReferences from '../../utils/references/usesReferences.js';
+import { getReferences } from '../../utils/references/getReferences.js';
+
+/**
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ */
+
+/**
+ * Applies reference-safe ordering to a pre-sorted token array.
+ * This function enforces define-before-use semantics when outputReferences=true,
+ * while preserving the user's existing sort order as much as possible.
+ *
+ * Algorithm: Stable topological sort using Kahn's algorithm variant.
+ * - Builds a dependency graph from token references
+ * - Processes nodes in topological order, but when multiple nodes are available
+ *   (no dependencies), chooses the one that appears earliest in the original sorted order
+ * - Handles cycles by keeping original order for cycle participants
+ * - Ignores references to tokens not in sortedTokens
+ *
+ * @memberof module:formatHelpers
+ * @param {Token[]} sortedTokens - Tokens already sorted by user sorters
+ * @param {Tokens} tokens - Full token dictionary for reference resolution
+ * @param {{unfilteredTokens?: Tokens, usesDtcg?: boolean}} [opts] - Options
+ * @returns {Token[]} - Reference-safe ordered tokens, preserving original order when possible
+ *
+ * @example
+ * ```javascript
+ * const userSorted = [tokenC, tokenD, tokenA, tokenB];
+ * // tokenA references tokenB, tokenC references tokenA
+ * const safeOrdered = applyReferenceSafeOrdering(userSorted, tokens, { usesDtcg: false });
+ * // Result: [tokenB, tokenA, tokenC, tokenD] (minimal reordering)
+ * ```
+ */
+export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = {}) {
+  const { unfilteredTokens, usesDtcg = false } = opts;
+  const valueKey = usesDtcg ? '$value' : 'value';
+
+  // Early return if no tokens
+  if (sortedTokens.length === 0) {
+    return sortedTokens;
+  }
+
+  // Build a map from token name to token for O(1) lookups
+  const tokenMap = new Map();
+  for (const token of sortedTokens) {
+    if (token && token.name) {
+      tokenMap.set(token.name, token);
+    }
+  }
+
+  // Build a map from token name to its original index in sortedTokens
+  // This preserves stability: when multiple tokens are available, choose the earliest one
+  const originalIndex = new Map();
+  sortedTokens.forEach((token, idx) => {
+    if (token && token.name) {
+      originalIndex.set(token.name, idx);
+    }
+  });
+
+  // Build dependency graph: for each token, collect its dependencies (tokens it references)
+  // dependencies[tokenName] = Set of token names that this token depends on
+  const dependencies = new Map();
+  const dependents = new Map(); // Reverse: dependents[tokenName] = Set of tokens that depend on this token
+
+  // Initialize maps
+  for (const token of sortedTokens) {
+    if (!token || !token.name) continue;
+    dependencies.set(token.name, new Set());
+    dependents.set(token.name, new Set());
+  }
+
+  // Populate dependencies by extracting references from each token
+  for (const token of sortedTokens) {
+    if (!token || !token.name || !token.original) continue;
+
+    const originalValue = token.original[valueKey];
+    if (!originalValue) continue;
+
+    // Check if this token uses references
+    if (!usesReferences(originalValue)) continue;
+
+    // Get all references for this token
+    const refs = getReferences(originalValue, tokens, {
+      unfilteredTokens,
+      usesDtcg,
+      warnImmediately: false,
+    });
+
+    // Only consider references that are in sortedTokens
+    for (const ref of refs) {
+      if (ref && ref.name && tokenMap.has(ref.name)) {
+        // token depends on ref
+        dependencies.get(token.name).add(ref.name);
+        // ref is depended upon by token
+        dependents.get(ref.name).add(token.name);
+      }
+    }
+  }
+
+  // Kahn's algorithm with stable ordering
+  // inDegree[tokenName] = number of dependencies that haven't been processed yet
+  const inDegree = new Map();
+  for (const token of sortedTokens) {
+    if (!token || !token.name) continue;
+    inDegree.set(token.name, dependencies.get(token.name).size);
+  }
+
+  // Priority queue: tokens with no remaining dependencies, ordered by original index
+  // We use an array and sort it by originalIndex to maintain stability
+  const available = [];
+  for (const token of sortedTokens) {
+    if (!token || !token.name) continue;
+    if (inDegree.get(token.name) === 0) {
+      available.push(token.name);
+    }
+  }
+
+  // Sort available tokens by their original index to maintain stability
+  available.sort((a, b) => originalIndex.get(a) - originalIndex.get(b));
+
+  const result = [];
+  const processed = new Set();
+
+  // Process tokens in topological order
+  while (available.length > 0) {
+    // Take the token with the earliest original index (stable ordering)
+    const tokenName = available.shift();
+    if (!tokenName || processed.has(tokenName)) continue;
+
+    const token = tokenMap.get(tokenName);
+    if (!token) continue;
+
+    result.push(token);
+    processed.add(tokenName);
+
+    // Decrease in-degree for all dependents
+    const tokenDependents = dependents.get(tokenName);
+    if (tokenDependents) {
+      for (const dependentName of tokenDependents) {
+        const currentInDegree = inDegree.get(dependentName);
+        if (currentInDegree !== undefined && currentInDegree > 0) {
+          const newInDegree = currentInDegree - 1;
+          inDegree.set(dependentName, newInDegree);
+
+          // If this dependent now has no remaining dependencies, add it to available
+          if (newInDegree === 0) {
+            available.push(dependentName);
+            // Re-sort to maintain stability (only the newly added item needs to find its place)
+            available.sort((a, b) => originalIndex.get(a) - originalIndex.get(b));
+          }
+        }
+      }
+    }
+  }
+
+  // Handle cycles: if there are unprocessed tokens, they form cycles
+  // Add them in their original order (deterministic fallback)
+  const cycleTokens = [];
+  for (const token of sortedTokens) {
+    if (token && token.name && !processed.has(token.name)) {
+      cycleTokens.push(token);
+    }
+  }
+
+  // Sort cycle tokens by original index to maintain determinism
+  cycleTokens.sort((a, b) => originalIndex.get(a.name) - originalIndex.get(b.name));
+
+  // Append cycle tokens to result
+  result.push(...cycleTokens);
+
+  return result;
+}

--- a/lib/common/formatHelpers/applyReferenceSafeOrdering.js
+++ b/lib/common/formatHelpers/applyReferenceSafeOrdering.js
@@ -75,7 +75,7 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
     if (!token || !token.name || !token.original) continue;
 
     const originalValue = token.original[valueKey];
-    if (!originalValue) continue;
+    if (originalValue == null) continue;
 
     // Check if this token uses references
     if (!usesReferences(originalValue)) continue;
@@ -123,9 +123,21 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
   const processed = new Set();
 
   // Process tokens in topological order
-  while (available.length > 0) {
-    // Take the token with the earliest original index (stable ordering)
-    const tokenName = available.shift();
+  // Continue until all tokens are processed, even if available queue is empty (handles cycles)
+  while (processed.size < tokenMap.size) {
+    let tokenName = available.shift();
+
+    // If no available tokens but unprocessed remain, pick earliest unprocessed token
+    // This handles cycles and ensures all tokens are processed
+    if (!tokenName) {
+      for (const token of sortedTokens) {
+        if (token && token.name && tokenMap.has(token.name) && !processed.has(token.name)) {
+          tokenName = token.name;
+          break;
+        }
+      }
+    }
+
     if (!tokenName || processed.has(tokenName)) continue;
 
     const token = tokenMap.get(tokenName);
@@ -146,28 +158,16 @@ export default function applyReferenceSafeOrdering(sortedTokens, tokens, opts = 
           // If this dependent now has no remaining dependencies, add it to available
           if (newInDegree === 0) {
             available.push(dependentName);
-            // Re-sort to maintain stability (only the newly added item needs to find its place)
-            available.sort((a, b) => originalIndex.get(a) - originalIndex.get(b));
           }
         }
       }
     }
-  }
 
-  // Handle cycles: if there are unprocessed tokens, they form cycles
-  // Add them in their original order (deterministic fallback)
-  const cycleTokens = [];
-  for (const token of sortedTokens) {
-    if (token && token.name && !processed.has(token.name)) {
-      cycleTokens.push(token);
+    // Re-sort to maintain stability (only when multiple items to avoid unnecessary sorting)
+    if (available.length > 1) {
+      available.sort((a, b) => originalIndex.get(a) - originalIndex.get(b));
     }
   }
-
-  // Sort cycle tokens by original index to maintain determinism
-  cycleTokens.sort((a, b) => originalIndex.get(a.name) - originalIndex.get(b.name));
-
-  // Append cycle tokens to result
-  result.push(...cycleTokens);
 
   return result;
 }

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -1,6 +1,6 @@
 import createPropertyFormatter from './createPropertyFormatter.js';
-import sortByReference from './sortByReference.js';
 import sortByName from './sortByName.js';
+import applyReferenceSafeOrdering from './applyReferenceSafeOrdering.js';
 
 /**
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
@@ -66,12 +66,6 @@ export default function formattedVariables({
 
   const sortInputs = sort ? (Array.isArray(sort) ? sort : [sort]) : [];
 
-  // reference-safety sorter is an internal concern:
-  // we only compute it when outputReferences=true
-  const byReference = outputReferences
-    ? sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens, usesDtcg })
-    : null;
-
   /**
    * @param {SortFn} keyOrFn
    * @returns {((a: Token, b: Token) => number) | null}
@@ -102,23 +96,26 @@ export default function formattedVariables({
    */
   const isComparator = (s) => s !== null;
 
-  const requestedSorters = sortInputs.map(normalize).filter(isComparator);
+  const requestedSort = sortInputs.map(normalize).filter(isComparator);
 
-  // If outputReferences=true, enforce reference-safe ordering first (define-before-use safety).
-  // The user-provided sort acts as a tie-breaker on top.
-  const comparators = outputReferences
-    ? [byReference, ...requestedSorters].filter(isComparator)
-    : requestedSorters.filter(isComparator);
-
-  if (comparators.length > 0) {
+  if (requestedSort.length > 0) {
     // note: using the spread operator here so we get a new array rather than
     // mutating the original
     allTokens = [...allTokens].sort((a, b) => {
-      for (const cmp of comparators) {
-        const r = cmp(a, b);
-        if (r !== 0) return r;
+      for (const rs of requestedSort) {
+        const result = rs(a, b);
+        if (result !== 0) return result;
       }
       return 0;
+    });
+  }
+
+  // If outputReferences=true, apply reference-safe ordering as a final pass
+  // This enforces define-before-use while preserving the user's sort order as much as possible
+  if (outputReferences) {
+    allTokens = applyReferenceSafeOrdering(allTokens, tokens, {
+      unfilteredTokens: dictionary.unfilteredTokens,
+      usesDtcg,
     });
   }
 


### PR DESCRIPTION
Follow-up work for https://github.com/style-dictionary/style-dictionary/pull/1611 🙇

## Description

This PR improves `formattedVariables` ordering behavior when `outputReferences: true` by ensuring **define-before-use** semantics without unnecessarily reshuffling tokens.

Instead of relying on a comparator-style reference sorter, we introduce a dedicated final-pass utility, `applyReferenceSafeOrdering(sortedTokens, tokens, opts)`, which **starts from the user-sorted array** and performs a **stable, reference-safe ordering pass**.

This approach preserves the user's sort order as much as possible while guaranteeing referenced tokens are defined before the tokens that use them.

## Changes

- **New utility: `applyReferenceSafeOrdering`**
  - Enforces reference-safe ordering (define-before-use) as a final pass.
  - Uses a stable Kahn-style topological ordering strategy.
  - Keeps ordering deterministic across runs.
  - Handles cycles gracefully via a deterministic fallback (does not crash).

- **`formattedVariables` integration**
  - First applies user sorters to produce `sortedTokens`.
  - When `outputReferences: true`, runs `applyReferenceSafeOrdering` as the final pass.
  - No additional sorters are applied after the reference-safe adjustment.

- **Stability fix**
  - Ensures the initial `available` queue is sorted by `originalIndex`, so that when multiple nodes are available, we always pick the earliest token from the user-sorted order.

- **Tests**
  - Added unit tests covering:
    - no references (order preserved)
    - direct dependencies
    - transitive dependencies
    - minimal movement from a user order like `(c, d, a, b)`
    - ignoring references to tokens not present in `sortedTokens`
    - cycles (deterministic, non-crashing fallback)
    - DTCG (`usesDtcg: true`)

## Motivation

When emitting CSS/SCSS/LESS/Stylus variables with `outputReferences: true`, we must guarantee that referenced tokens are defined before use. However, users also expect their chosen sorting strategy (e.g. by name or custom comparator) to be preserved whenever possible.

A dedicated final-pass reordering step makes the responsibility explicit:
- **User sorting** happens first.
- **Reference safety** is applied last, with minimal movement.

This yields more predictable output and avoids unnecessary reshuffling.