### PR TITLE
feat: add support for XAML format

### DIFF
--- a/.changeset/spicy-buckets-switch.md
+++ b/.changeset/spicy-buckets-switch.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': minor
+---
+
+Add support for XAML output

--- a/__integration__/__snapshots__/xaml.test.snap.js
+++ b/__integration__/__snapshots__/xaml.test.snap.js
@@ -1,0 +1,979 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["integration xaml xaml/resourceDictionary should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Color x:Key="ColorBackgroundPrimary">#FFFFFFFF</Color>
+  <Color x:Key="ColorBackgroundSecondary">#FFF3F4F4</Color>
+  <Color x:Key="ColorBackgroundTertiary">#FFDEE1E1</Color>
+  <Color x:Key="ColorBackgroundDanger">#FFFFEAE9</Color>
+  <Color x:Key="ColorBackgroundWarning">#FFFFEDE3</Color>
+  <Color x:Key="ColorBackgroundSuccess">#FFEBF9EB</Color>
+  <Color x:Key="ColorBackgroundInfo">#FFE9F8FF</Color>
+  <Color x:Key="ColorBackgroundDisabled">#FFDEE1E1</Color>
+  <Color x:Key="ColorBorderPrimary">#FFC8CCCC</Color>
+  <Color x:Key="ColorBrandPrimary">#FF0B8599</Color>
+  <Color x:Key="ColorBrandSecondary">#FF6F5ED3</Color>
+  <Color x:Key="ColorCoreGreen0">#FFEBF9EB</Color>
+  <Color x:Key="ColorCoreGreen100">#FFD7F4D7</Color>
+  <Color x:Key="ColorCoreGreen200">#FFC2F2BD</Color>
+  <Color x:Key="ColorCoreGreen300">#FF98E58E</Color>
+  <Color x:Key="ColorCoreGreen400">#FF75DD66</Color>
+  <Color x:Key="ColorCoreGreen500">#FF59CB59</Color>
+  <Color x:Key="ColorCoreGreen600">#FF2BB656</Color>
+  <Color x:Key="ColorCoreGreen700">#FF0CA750</Color>
+  <Color x:Key="ColorCoreGreen800">#FF008B46</Color>
+  <Color x:Key="ColorCoreGreen900">#FF006B40</Color>
+  <Color x:Key="ColorCoreGreen1000">#FF08422F</Color>
+  <Color x:Key="ColorCoreGreen1100">#FF002B20</Color>
+  <Color x:Key="ColorCoreTeal0">#FFE5F9F5</Color>
+  <Color x:Key="ColorCoreTeal100">#FFCDF7EF</Color>
+  <Color x:Key="ColorCoreTeal200">#FFB3F2E6</Color>
+  <Color x:Key="ColorCoreTeal300">#FF7DEAD5</Color>
+  <Color x:Key="ColorCoreTeal400">#FF24E0C5</Color>
+  <Color x:Key="ColorCoreTeal500">#FF08C4B2</Color>
+  <Color x:Key="ColorCoreTeal600">#FF00A99C</Color>
+  <Color x:Key="ColorCoreTeal700">#FF0B968F</Color>
+  <Color x:Key="ColorCoreTeal800">#FF067C7C</Color>
+  <Color x:Key="ColorCoreTeal900">#FF026661</Color>
+  <Color x:Key="ColorCoreTeal1000">#FF083F3F</Color>
+  <Color x:Key="ColorCoreTeal1100">#FF002528</Color>
+  <Color x:Key="ColorCoreAqua0">#FFD9FCFB</Color>
+  <Color x:Key="ColorCoreAqua100">#FFC5F9F9</Color>
+  <Color x:Key="ColorCoreAqua200">#FFA5F2F2</Color>
+  <Color x:Key="ColorCoreAqua300">#FF76E5E2</Color>
+  <Color x:Key="ColorCoreAqua400">#FF33D6E2</Color>
+  <Color x:Key="ColorCoreAqua500">#FF17B8CE</Color>
+  <Color x:Key="ColorCoreAqua600">#FF0797AE</Color>
+  <Color x:Key="ColorCoreAqua700">#FF0B8599</Color>
+  <Color x:Key="ColorCoreAqua800">#FF0F6E84</Color>
+  <Color x:Key="ColorCoreAqua900">#FF035E73</Color>
+  <Color x:Key="ColorCoreAqua1000">#FF083D4F</Color>
+  <Color x:Key="ColorCoreAqua1100">#FF002838</Color>
+  <Color x:Key="ColorCoreBlue0">#FFE9F8FF</Color>
+  <Color x:Key="ColorCoreBlue100">#FFDCF2FF</Color>
+  <Color x:Key="ColorCoreBlue200">#FFC7E4F9</Color>
+  <Color x:Key="ColorCoreBlue300">#FFA1D2F8</Color>
+  <Color x:Key="ColorCoreBlue400">#FF56ADF5</Color>
+  <Color x:Key="ColorCoreBlue500">#FF3896E3</Color>
+  <Color x:Key="ColorCoreBlue600">#FF2B87D3</Color>
+  <Color x:Key="ColorCoreBlue700">#FF2079C3</Color>
+  <Color x:Key="ColorCoreBlue800">#FF116DAA</Color>
+  <Color x:Key="ColorCoreBlue900">#FF0C5689</Color>
+  <Color x:Key="ColorCoreBlue1000">#FF0A3960</Color>
+  <Color x:Key="ColorCoreBlue1100">#FF002138</Color>
+  <Color x:Key="ColorCorePurple0">#FFF2F2F9</Color>
+  <Color x:Key="ColorCorePurple100">#FFEAEAF9</Color>
+  <Color x:Key="ColorCorePurple200">#FFD8D7F9</Color>
+  <Color x:Key="ColorCorePurple300">#FFC1C1F7</Color>
+  <Color x:Key="ColorCorePurple400">#FFA193F2</Color>
+  <Color x:Key="ColorCorePurple500">#FF9180F4</Color>
+  <Color x:Key="ColorCorePurple600">#FF816FEA</Color>
+  <Color x:Key="ColorCorePurple700">#FF6F5ED3</Color>
+  <Color x:Key="ColorCorePurple800">#FF5E4EBA</Color>
+  <Color x:Key="ColorCorePurple900">#FF483A9C</Color>
+  <Color x:Key="ColorCorePurple1000">#FF2D246B</Color>
+  <Color x:Key="ColorCorePurple1100">#FF1D1D38</Color>
+  <Color x:Key="ColorCoreMagenta0">#FFFEF0FF</Color>
+  <Color x:Key="ColorCoreMagenta100">#FFF9E3FC</Color>
+  <Color x:Key="ColorCoreMagenta200">#FFF4C4F7</Color>
+  <Color x:Key="ColorCoreMagenta300">#FFEDADF2</Color>
+  <Color x:Key="ColorCoreMagenta400">#FFF282F5</Color>
+  <Color x:Key="ColorCoreMagenta500">#FFDB61DB</Color>
+  <Color x:Key="ColorCoreMagenta600">#FFC44EB9</Color>
+  <Color x:Key="ColorCoreMagenta700">#FFAC44A8</Color>
+  <Color x:Key="ColorCoreMagenta800">#FF8F3896</Color>
+  <Color x:Key="ColorCoreMagenta900">#FF6C2277</Color>
+  <Color x:Key="ColorCoreMagenta1000">#FF451551</Color>
+  <Color x:Key="ColorCoreMagenta1100">#FF29192D</Color>
+  <Color x:Key="ColorCorePink0">#FFFFE9F3</Color>
+  <Color x:Key="ColorCorePink100">#FFFCDBEB</Color>
+  <Color x:Key="ColorCorePink200">#FFFFB5D5</Color>
+  <Color x:Key="ColorCorePink300">#FFFF95C1</Color>
+  <Color x:Key="ColorCorePink400">#FFFF76AE</Color>
+  <Color x:Key="ColorCorePink500">#FFEF588B</Color>
+  <Color x:Key="ColorCorePink600">#FFE0447C</Color>
+  <Color x:Key="ColorCorePink700">#FFCE3665</Color>
+  <Color x:Key="ColorCorePink800">#FFB22F5B</Color>
+  <Color x:Key="ColorCorePink900">#FF931847</Color>
+  <Color x:Key="ColorCorePink1000">#FF561231</Color>
+  <Color x:Key="ColorCorePink1100">#FF2B1721</Color>
+  <Color x:Key="ColorCoreRed0">#FFFFEAE9</Color>
+  <Color x:Key="ColorCoreRed100">#FFFFD5D2</Color>
+  <Color x:Key="ColorCoreRed200">#FFFFB8B1</Color>
+  <Color x:Key="ColorCoreRed300">#FFFF9C8F</Color>
+  <Color x:Key="ColorCoreRed400">#FFFF7F6E</Color>
+  <Color x:Key="ColorCoreRed500">#FFF76054</Color>
+  <Color x:Key="ColorCoreRed600">#FFED4C42</Color>
+  <Color x:Key="ColorCoreRed700">#FFDB3E3E</Color>
+  <Color x:Key="ColorCoreRed800">#FFC63434</Color>
+  <Color x:Key="ColorCoreRed900">#FF992222</Color>
+  <Color x:Key="ColorCoreRed1000">#FF6D1313</Color>
+  <Color x:Key="ColorCoreRed1100">#FF2B1111</Color>
+  <Color x:Key="ColorCoreOrange0">#FFFFEDE3</Color>
+  <Color x:Key="ColorCoreOrange100">#FFFCDCCC</Color>
+  <Color x:Key="ColorCoreOrange200">#FFFFC6A4</Color>
+  <Color x:Key="ColorCoreOrange300">#FFFFB180</Color>
+  <Color x:Key="ColorCoreOrange400">#FFFF9C5D</Color>
+  <Color x:Key="ColorCoreOrange500">#FFFC8943</Color>
+  <Color x:Key="ColorCoreOrange600">#FFF57D33</Color>
+  <Color x:Key="ColorCoreOrange700">#FFED7024</Color>
+  <Color x:Key="ColorCoreOrange800">#FFCE5511</Color>
+  <Color x:Key="ColorCoreOrange900">#FF962C0B</Color>
+  <Color x:Key="ColorCoreOrange1000">#FF601700</Color>
+  <Color x:Key="ColorCoreOrange1100">#FF2D130E</Color>
+  <Color x:Key="ColorCoreNeutral0">#FFFFFFFF</Color>
+  <Color x:Key="ColorCoreNeutral100">#FFF3F4F4</Color>
+  <Color x:Key="ColorCoreNeutral200">#FFDEE1E1</Color>
+  <Color x:Key="ColorCoreNeutral300">#FFC8CCCC</Color>
+  <Color x:Key="ColorCoreNeutral400">#FFB0B6B7</Color>
+  <Color x:Key="ColorCoreNeutral500">#FF929A9B</Color>
+  <Color x:Key="ColorCoreNeutral600">#FF6E797A</Color>
+  <Color x:Key="ColorCoreNeutral700">#FF515E5F</Color>
+  <Color x:Key="ColorCoreNeutral800">#FF364141</Color>
+  <Color x:Key="ColorCoreNeutral900">#FF273333</Color>
+  <Color x:Key="ColorCoreNeutral1000">#FF162020</Color>
+  <Color x:Key="ColorCoreNeutral1100">#FF040404</Color>
+  <Color x:Key="ColorCoreYellow0">#FFFFF8E2</Color>
+  <Color x:Key="ColorCoreYellow100">#FFFDEFCD</Color>
+  <Color x:Key="ColorCoreYellow200">#FFFFE99A</Color>
+  <Color x:Key="ColorCoreYellow300">#FFFFE16E</Color>
+  <Color x:Key="ColorCoreYellow400">#FFFFD943</Color>
+  <Color x:Key="ColorCoreYellow500">#FFFFCD1C</Color>
+  <Color x:Key="ColorCoreYellow600">#FFFFBC00</Color>
+  <Color x:Key="ColorCoreYellow700">#FFDD9903</Color>
+  <Color x:Key="ColorCoreYellow800">#FFBA7506</Color>
+  <Color x:Key="ColorCoreYellow900">#FF944C0C</Color>
+  <Color x:Key="ColorCoreYellow1000">#FF542A00</Color>
+  <Color x:Key="ColorCoreYellow1100">#FF2D1A05</Color>
+  <Color x:Key="ColorFontPrimary">#FF040404</Color>
+  <Color x:Key="ColorFontSecondary">#FF273333</Color>
+  <Color x:Key="ColorFontTertiary">#FF364141</Color>
+  <Color x:Key="ColorFontInteractive">#FF0B8599</Color>
+  <Color x:Key="ColorFontInteractiveHover">#FF0B8599</Color>
+  <Color x:Key="ColorFontInteractiveActive">#FF6F5ED3</Color>
+  <Color x:Key="ColorFontInteractiveDisabled">#FF364141</Color>
+  <Color x:Key="ColorFontDanger">#FF6D1313</Color>
+  <Color x:Key="ColorFontWarning">#FF601700</Color>
+  <Color x:Key="ColorFontSuccess">#FF08422F</Color>
+  <x:Double x:Key="SizeBorderRadiusLarge">480.00</x:Double>
+  <x:Double x:Key="SizeBorderRadiusMedium">384.00</x:Double>
+  <x:Double x:Key="SizeBorderRadiusSmall">256.00</x:Double>
+  <x:Double x:Key="SizeFontSmall">12.00</x:Double>
+  <x:Double x:Key="SizeFontMedium">16.00</x:Double>
+  <x:Double x:Key="SizeFontLarge">24.00</x:Double>
+  <x:Double x:Key="SizeFontXl">36.00</x:Double>
+  <x:Double x:Key="SizePaddingSmall">8.00</x:Double>
+  <x:Double x:Key="SizePaddingMedium">16.00</x:Double>
+  <x:Double x:Key="SizePaddingLarge">16.00</x:Double>
+  <x:Double x:Key="SizePaddingXl">16.00</x:Double>
+  <SolidColorBrush x:Key="ColorBackgroundPrimaryBrush" Color="{StaticResource ColorBackgroundPrimary}" />
+  <SolidColorBrush x:Key="ColorBackgroundSecondaryBrush" Color="{StaticResource ColorBackgroundSecondary}" />
+  <SolidColorBrush x:Key="ColorBackgroundTertiaryBrush" Color="{StaticResource ColorBackgroundTertiary}" />
+  <SolidColorBrush x:Key="ColorBackgroundDangerBrush" Color="{StaticResource ColorBackgroundDanger}" />
+  <SolidColorBrush x:Key="ColorBackgroundWarningBrush" Color="{StaticResource ColorBackgroundWarning}" />
+  <SolidColorBrush x:Key="ColorBackgroundSuccessBrush" Color="{StaticResource ColorBackgroundSuccess}" />
+  <SolidColorBrush x:Key="ColorBackgroundInfoBrush" Color="{StaticResource ColorBackgroundInfo}" />
+  <SolidColorBrush x:Key="ColorBackgroundDisabledBrush" Color="{StaticResource ColorBackgroundDisabled}" />
+  <SolidColorBrush x:Key="ColorBorderPrimaryBrush" Color="{StaticResource ColorBorderPrimary}" />
+  <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{StaticResource ColorBrandPrimary}" />
+  <SolidColorBrush x:Key="ColorBrandSecondaryBrush" Color="{StaticResource ColorBrandSecondary}" />
+  <SolidColorBrush x:Key="ColorCoreGreen0Brush" Color="{StaticResource ColorCoreGreen0}" />
+  <SolidColorBrush x:Key="ColorCoreGreen100Brush" Color="{StaticResource ColorCoreGreen100}" />
+  <SolidColorBrush x:Key="ColorCoreGreen200Brush" Color="{StaticResource ColorCoreGreen200}" />
+  <SolidColorBrush x:Key="ColorCoreGreen300Brush" Color="{StaticResource ColorCoreGreen300}" />
+  <SolidColorBrush x:Key="ColorCoreGreen400Brush" Color="{StaticResource ColorCoreGreen400}" />
+  <SolidColorBrush x:Key="ColorCoreGreen500Brush" Color="{StaticResource ColorCoreGreen500}" />
+  <SolidColorBrush x:Key="ColorCoreGreen600Brush" Color="{StaticResource ColorCoreGreen600}" />
+  <SolidColorBrush x:Key="ColorCoreGreen700Brush" Color="{StaticResource ColorCoreGreen700}" />
+  <SolidColorBrush x:Key="ColorCoreGreen800Brush" Color="{StaticResource ColorCoreGreen800}" />
+  <SolidColorBrush x:Key="ColorCoreGreen900Brush" Color="{StaticResource ColorCoreGreen900}" />
+  <SolidColorBrush x:Key="ColorCoreGreen1000Brush" Color="{StaticResource ColorCoreGreen1000}" />
+  <SolidColorBrush x:Key="ColorCoreGreen1100Brush" Color="{StaticResource ColorCoreGreen1100}" />
+  <SolidColorBrush x:Key="ColorCoreTeal0Brush" Color="{StaticResource ColorCoreTeal0}" />
+  <SolidColorBrush x:Key="ColorCoreTeal100Brush" Color="{StaticResource ColorCoreTeal100}" />
+  <SolidColorBrush x:Key="ColorCoreTeal200Brush" Color="{StaticResource ColorCoreTeal200}" />
+  <SolidColorBrush x:Key="ColorCoreTeal300Brush" Color="{StaticResource ColorCoreTeal300}" />
+  <SolidColorBrush x:Key="ColorCoreTeal400Brush" Color="{StaticResource ColorCoreTeal400}" />
+  <SolidColorBrush x:Key="ColorCoreTeal500Brush" Color="{StaticResource ColorCoreTeal500}" />
+  <SolidColorBrush x:Key="ColorCoreTeal600Brush" Color="{StaticResource ColorCoreTeal600}" />
+  <SolidColorBrush x:Key="ColorCoreTeal700Brush" Color="{StaticResource ColorCoreTeal700}" />
+  <SolidColorBrush x:Key="ColorCoreTeal800Brush" Color="{StaticResource ColorCoreTeal800}" />
+  <SolidColorBrush x:Key="ColorCoreTeal900Brush" Color="{StaticResource ColorCoreTeal900}" />
+  <SolidColorBrush x:Key="ColorCoreTeal1000Brush" Color="{StaticResource ColorCoreTeal1000}" />
+  <SolidColorBrush x:Key="ColorCoreTeal1100Brush" Color="{StaticResource ColorCoreTeal1100}" />
+  <SolidColorBrush x:Key="ColorCoreAqua0Brush" Color="{StaticResource ColorCoreAqua0}" />
+  <SolidColorBrush x:Key="ColorCoreAqua100Brush" Color="{StaticResource ColorCoreAqua100}" />
+  <SolidColorBrush x:Key="ColorCoreAqua200Brush" Color="{StaticResource ColorCoreAqua200}" />
+  <SolidColorBrush x:Key="ColorCoreAqua300Brush" Color="{StaticResource ColorCoreAqua300}" />
+  <SolidColorBrush x:Key="ColorCoreAqua400Brush" Color="{StaticResource ColorCoreAqua400}" />
+  <SolidColorBrush x:Key="ColorCoreAqua500Brush" Color="{StaticResource ColorCoreAqua500}" />
+  <SolidColorBrush x:Key="ColorCoreAqua600Brush" Color="{StaticResource ColorCoreAqua600}" />
+  <SolidColorBrush x:Key="ColorCoreAqua700Brush" Color="{StaticResource ColorCoreAqua700}" />
+  <SolidColorBrush x:Key="ColorCoreAqua800Brush" Color="{StaticResource ColorCoreAqua800}" />
+  <SolidColorBrush x:Key="ColorCoreAqua900Brush" Color="{StaticResource ColorCoreAqua900}" />
+  <SolidColorBrush x:Key="ColorCoreAqua1000Brush" Color="{StaticResource ColorCoreAqua1000}" />
+  <SolidColorBrush x:Key="ColorCoreAqua1100Brush" Color="{StaticResource ColorCoreAqua1100}" />
+  <SolidColorBrush x:Key="ColorCoreBlue0Brush" Color="{StaticResource ColorCoreBlue0}" />
+  <SolidColorBrush x:Key="ColorCoreBlue100Brush" Color="{StaticResource ColorCoreBlue100}" />
+  <SolidColorBrush x:Key="ColorCoreBlue200Brush" Color="{StaticResource ColorCoreBlue200}" />
+  <SolidColorBrush x:Key="ColorCoreBlue300Brush" Color="{StaticResource ColorCoreBlue300}" />
+  <SolidColorBrush x:Key="ColorCoreBlue400Brush" Color="{StaticResource ColorCoreBlue400}" />
+  <SolidColorBrush x:Key="ColorCoreBlue500Brush" Color="{StaticResource ColorCoreBlue500}" />
+  <SolidColorBrush x:Key="ColorCoreBlue600Brush" Color="{StaticResource ColorCoreBlue600}" />
+  <SolidColorBrush x:Key="ColorCoreBlue700Brush" Color="{StaticResource ColorCoreBlue700}" />
+  <SolidColorBrush x:Key="ColorCoreBlue800Brush" Color="{StaticResource ColorCoreBlue800}" />
+  <SolidColorBrush x:Key="ColorCoreBlue900Brush" Color="{StaticResource ColorCoreBlue900}" />
+  <SolidColorBrush x:Key="ColorCoreBlue1000Brush" Color="{StaticResource ColorCoreBlue1000}" />
+  <SolidColorBrush x:Key="ColorCoreBlue1100Brush" Color="{StaticResource ColorCoreBlue1100}" />
+  <SolidColorBrush x:Key="ColorCorePurple0Brush" Color="{StaticResource ColorCorePurple0}" />
+  <SolidColorBrush x:Key="ColorCorePurple100Brush" Color="{StaticResource ColorCorePurple100}" />
+  <SolidColorBrush x:Key="ColorCorePurple200Brush" Color="{StaticResource ColorCorePurple200}" />
+  <SolidColorBrush x:Key="ColorCorePurple300Brush" Color="{StaticResource ColorCorePurple300}" />
+  <SolidColorBrush x:Key="ColorCorePurple400Brush" Color="{StaticResource ColorCorePurple400}" />
+  <SolidColorBrush x:Key="ColorCorePurple500Brush" Color="{StaticResource ColorCorePurple500}" />
+  <SolidColorBrush x:Key="ColorCorePurple600Brush" Color="{StaticResource ColorCorePurple600}" />
+  <SolidColorBrush x:Key="ColorCorePurple700Brush" Color="{StaticResource ColorCorePurple700}" />
+  <SolidColorBrush x:Key="ColorCorePurple800Brush" Color="{StaticResource ColorCorePurple800}" />
+  <SolidColorBrush x:Key="ColorCorePurple900Brush" Color="{StaticResource ColorCorePurple900}" />
+  <SolidColorBrush x:Key="ColorCorePurple1000Brush" Color="{StaticResource ColorCorePurple1000}" />
+  <SolidColorBrush x:Key="ColorCorePurple1100Brush" Color="{StaticResource ColorCorePurple1100}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta0Brush" Color="{StaticResource ColorCoreMagenta0}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta100Brush" Color="{StaticResource ColorCoreMagenta100}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta200Brush" Color="{StaticResource ColorCoreMagenta200}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta300Brush" Color="{StaticResource ColorCoreMagenta300}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta400Brush" Color="{StaticResource ColorCoreMagenta400}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta500Brush" Color="{StaticResource ColorCoreMagenta500}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta600Brush" Color="{StaticResource ColorCoreMagenta600}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta700Brush" Color="{StaticResource ColorCoreMagenta700}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta800Brush" Color="{StaticResource ColorCoreMagenta800}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta900Brush" Color="{StaticResource ColorCoreMagenta900}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta1000Brush" Color="{StaticResource ColorCoreMagenta1000}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta1100Brush" Color="{StaticResource ColorCoreMagenta1100}" />
+  <SolidColorBrush x:Key="ColorCorePink0Brush" Color="{StaticResource ColorCorePink0}" />
+  <SolidColorBrush x:Key="ColorCorePink100Brush" Color="{StaticResource ColorCorePink100}" />
+  <SolidColorBrush x:Key="ColorCorePink200Brush" Color="{StaticResource ColorCorePink200}" />
+  <SolidColorBrush x:Key="ColorCorePink300Brush" Color="{StaticResource ColorCorePink300}" />
+  <SolidColorBrush x:Key="ColorCorePink400Brush" Color="{StaticResource ColorCorePink400}" />
+  <SolidColorBrush x:Key="ColorCorePink500Brush" Color="{StaticResource ColorCorePink500}" />
+  <SolidColorBrush x:Key="ColorCorePink600Brush" Color="{StaticResource ColorCorePink600}" />
+  <SolidColorBrush x:Key="ColorCorePink700Brush" Color="{StaticResource ColorCorePink700}" />
+  <SolidColorBrush x:Key="ColorCorePink800Brush" Color="{StaticResource ColorCorePink800}" />
+  <SolidColorBrush x:Key="ColorCorePink900Brush" Color="{StaticResource ColorCorePink900}" />
+  <SolidColorBrush x:Key="ColorCorePink1000Brush" Color="{StaticResource ColorCorePink1000}" />
+  <SolidColorBrush x:Key="ColorCorePink1100Brush" Color="{StaticResource ColorCorePink1100}" />
+  <SolidColorBrush x:Key="ColorCoreRed0Brush" Color="{StaticResource ColorCoreRed0}" />
+  <SolidColorBrush x:Key="ColorCoreRed100Brush" Color="{StaticResource ColorCoreRed100}" />
+  <SolidColorBrush x:Key="ColorCoreRed200Brush" Color="{StaticResource ColorCoreRed200}" />
+  <SolidColorBrush x:Key="ColorCoreRed300Brush" Color="{StaticResource ColorCoreRed300}" />
+  <SolidColorBrush x:Key="ColorCoreRed400Brush" Color="{StaticResource ColorCoreRed400}" />
+  <SolidColorBrush x:Key="ColorCoreRed500Brush" Color="{StaticResource ColorCoreRed500}" />
+  <SolidColorBrush x:Key="ColorCoreRed600Brush" Color="{StaticResource ColorCoreRed600}" />
+  <SolidColorBrush x:Key="ColorCoreRed700Brush" Color="{StaticResource ColorCoreRed700}" />
+  <SolidColorBrush x:Key="ColorCoreRed800Brush" Color="{StaticResource ColorCoreRed800}" />
+  <SolidColorBrush x:Key="ColorCoreRed900Brush" Color="{StaticResource ColorCoreRed900}" />
+  <SolidColorBrush x:Key="ColorCoreRed1000Brush" Color="{StaticResource ColorCoreRed1000}" />
+  <SolidColorBrush x:Key="ColorCoreRed1100Brush" Color="{StaticResource ColorCoreRed1100}" />
+  <SolidColorBrush x:Key="ColorCoreOrange0Brush" Color="{StaticResource ColorCoreOrange0}" />
+  <SolidColorBrush x:Key="ColorCoreOrange100Brush" Color="{StaticResource ColorCoreOrange100}" />
+  <SolidColorBrush x:Key="ColorCoreOrange200Brush" Color="{StaticResource ColorCoreOrange200}" />
+  <SolidColorBrush x:Key="ColorCoreOrange300Brush" Color="{StaticResource ColorCoreOrange300}" />
+  <SolidColorBrush x:Key="ColorCoreOrange400Brush" Color="{StaticResource ColorCoreOrange400}" />
+  <SolidColorBrush x:Key="ColorCoreOrange500Brush" Color="{StaticResource ColorCoreOrange500}" />
+  <SolidColorBrush x:Key="ColorCoreOrange600Brush" Color="{StaticResource ColorCoreOrange600}" />
+  <SolidColorBrush x:Key="ColorCoreOrange700Brush" Color="{StaticResource ColorCoreOrange700}" />
+  <SolidColorBrush x:Key="ColorCoreOrange800Brush" Color="{StaticResource ColorCoreOrange800}" />
+  <SolidColorBrush x:Key="ColorCoreOrange900Brush" Color="{StaticResource ColorCoreOrange900}" />
+  <SolidColorBrush x:Key="ColorCoreOrange1000Brush" Color="{StaticResource ColorCoreOrange1000}" />
+  <SolidColorBrush x:Key="ColorCoreOrange1100Brush" Color="{StaticResource ColorCoreOrange1100}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral0Brush" Color="{StaticResource ColorCoreNeutral0}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral100Brush" Color="{StaticResource ColorCoreNeutral100}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral200Brush" Color="{StaticResource ColorCoreNeutral200}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral300Brush" Color="{StaticResource ColorCoreNeutral300}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral400Brush" Color="{StaticResource ColorCoreNeutral400}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral500Brush" Color="{StaticResource ColorCoreNeutral500}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral600Brush" Color="{StaticResource ColorCoreNeutral600}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral700Brush" Color="{StaticResource ColorCoreNeutral700}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral800Brush" Color="{StaticResource ColorCoreNeutral800}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral900Brush" Color="{StaticResource ColorCoreNeutral900}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral1000Brush" Color="{StaticResource ColorCoreNeutral1000}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral1100Brush" Color="{StaticResource ColorCoreNeutral1100}" />
+  <SolidColorBrush x:Key="ColorCoreYellow0Brush" Color="{StaticResource ColorCoreYellow0}" />
+  <SolidColorBrush x:Key="ColorCoreYellow100Brush" Color="{StaticResource ColorCoreYellow100}" />
+  <SolidColorBrush x:Key="ColorCoreYellow200Brush" Color="{StaticResource ColorCoreYellow200}" />
+  <SolidColorBrush x:Key="ColorCoreYellow300Brush" Color="{StaticResource ColorCoreYellow300}" />
+  <SolidColorBrush x:Key="ColorCoreYellow400Brush" Color="{StaticResource ColorCoreYellow400}" />
+  <SolidColorBrush x:Key="ColorCoreYellow500Brush" Color="{StaticResource ColorCoreYellow500}" />
+  <SolidColorBrush x:Key="ColorCoreYellow600Brush" Color="{StaticResource ColorCoreYellow600}" />
+  <SolidColorBrush x:Key="ColorCoreYellow700Brush" Color="{StaticResource ColorCoreYellow700}" />
+  <SolidColorBrush x:Key="ColorCoreYellow800Brush" Color="{StaticResource ColorCoreYellow800}" />
+  <SolidColorBrush x:Key="ColorCoreYellow900Brush" Color="{StaticResource ColorCoreYellow900}" />
+  <SolidColorBrush x:Key="ColorCoreYellow1000Brush" Color="{StaticResource ColorCoreYellow1000}" />
+  <SolidColorBrush x:Key="ColorCoreYellow1100Brush" Color="{StaticResource ColorCoreYellow1100}" />
+  <SolidColorBrush x:Key="ColorFontPrimaryBrush" Color="{StaticResource ColorFontPrimary}" />
+  <SolidColorBrush x:Key="ColorFontSecondaryBrush" Color="{StaticResource ColorFontSecondary}" />
+  <SolidColorBrush x:Key="ColorFontTertiaryBrush" Color="{StaticResource ColorFontTertiary}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveBrush" Color="{StaticResource ColorFontInteractive}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveHoverBrush" Color="{StaticResource ColorFontInteractiveHover}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveActiveBrush" Color="{StaticResource ColorFontInteractiveActive}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveDisabledBrush" Color="{StaticResource ColorFontInteractiveDisabled}" />
+  <SolidColorBrush x:Key="ColorFontDangerBrush" Color="{StaticResource ColorFontDanger}" />
+  <SolidColorBrush x:Key="ColorFontWarningBrush" Color="{StaticResource ColorFontWarning}" />
+  <SolidColorBrush x:Key="ColorFontSuccessBrush" Color="{StaticResource ColorFontSuccess}" />
+</ResourceDictionary>
+`;
+/* end snapshot integration xaml xaml/resourceDictionary should match snapshot */
+
+snapshots["integration xaml xaml/resourceDictionary with references should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Color x:Key="ColorCoreGreen0">#FFEBF9EB</Color>
+  <Color x:Key="ColorCoreGreen100">#FFD7F4D7</Color>
+  <Color x:Key="ColorCoreGreen200">#FFC2F2BD</Color>
+  <Color x:Key="ColorCoreGreen300">#FF98E58E</Color>
+  <Color x:Key="ColorCoreGreen400">#FF75DD66</Color>
+  <Color x:Key="ColorCoreGreen500">#FF59CB59</Color>
+  <Color x:Key="ColorCoreGreen600">#FF2BB656</Color>
+  <Color x:Key="ColorCoreGreen700">#FF0CA750</Color>
+  <Color x:Key="ColorCoreGreen800">#FF008B46</Color>
+  <Color x:Key="ColorCoreGreen900">#FF006B40</Color>
+  <Color x:Key="ColorCoreGreen1000">#FF08422F</Color>
+  <Color x:Key="ColorCoreGreen1100">#FF002B20</Color>
+  <Color x:Key="ColorCoreTeal0">#FFE5F9F5</Color>
+  <Color x:Key="ColorCoreTeal100">#FFCDF7EF</Color>
+  <Color x:Key="ColorCoreTeal200">#FFB3F2E6</Color>
+  <Color x:Key="ColorCoreTeal300">#FF7DEAD5</Color>
+  <Color x:Key="ColorCoreTeal400">#FF24E0C5</Color>
+  <Color x:Key="ColorCoreTeal500">#FF08C4B2</Color>
+  <Color x:Key="ColorCoreTeal600">#FF00A99C</Color>
+  <Color x:Key="ColorCoreTeal700">#FF0B968F</Color>
+  <Color x:Key="ColorCoreTeal800">#FF067C7C</Color>
+  <Color x:Key="ColorCoreTeal900">#FF026661</Color>
+  <Color x:Key="ColorCoreTeal1000">#FF083F3F</Color>
+  <Color x:Key="ColorCoreTeal1100">#FF002528</Color>
+  <Color x:Key="ColorCoreAqua0">#FFD9FCFB</Color>
+  <Color x:Key="ColorCoreAqua100">#FFC5F9F9</Color>
+  <Color x:Key="ColorCoreAqua200">#FFA5F2F2</Color>
+  <Color x:Key="ColorCoreAqua300">#FF76E5E2</Color>
+  <Color x:Key="ColorCoreAqua400">#FF33D6E2</Color>
+  <Color x:Key="ColorCoreAqua500">#FF17B8CE</Color>
+  <Color x:Key="ColorCoreAqua600">#FF0797AE</Color>
+  <Color x:Key="ColorCoreAqua700">#FF0B8599</Color>
+  <Color x:Key="ColorCoreAqua800">#FF0F6E84</Color>
+  <Color x:Key="ColorCoreAqua900">#FF035E73</Color>
+  <Color x:Key="ColorCoreAqua1000">#FF083D4F</Color>
+  <Color x:Key="ColorCoreAqua1100">#FF002838</Color>
+  <Color x:Key="ColorCoreBlue0">#FFE9F8FF</Color>
+  <Color x:Key="ColorCoreBlue100">#FFDCF2FF</Color>
+  <Color x:Key="ColorCoreBlue200">#FFC7E4F9</Color>
+  <Color x:Key="ColorCoreBlue300">#FFA1D2F8</Color>
+  <Color x:Key="ColorCoreBlue400">#FF56ADF5</Color>
+  <Color x:Key="ColorCoreBlue500">#FF3896E3</Color>
+  <Color x:Key="ColorCoreBlue600">#FF2B87D3</Color>
+  <Color x:Key="ColorCoreBlue700">#FF2079C3</Color>
+  <Color x:Key="ColorCoreBlue800">#FF116DAA</Color>
+  <Color x:Key="ColorCoreBlue900">#FF0C5689</Color>
+  <Color x:Key="ColorCoreBlue1000">#FF0A3960</Color>
+  <Color x:Key="ColorCoreBlue1100">#FF002138</Color>
+  <Color x:Key="ColorCorePurple0">#FFF2F2F9</Color>
+  <Color x:Key="ColorCorePurple100">#FFEAEAF9</Color>
+  <Color x:Key="ColorCorePurple200">#FFD8D7F9</Color>
+  <Color x:Key="ColorCorePurple300">#FFC1C1F7</Color>
+  <Color x:Key="ColorCorePurple400">#FFA193F2</Color>
+  <Color x:Key="ColorCorePurple500">#FF9180F4</Color>
+  <Color x:Key="ColorCorePurple600">#FF816FEA</Color>
+  <Color x:Key="ColorCorePurple700">#FF6F5ED3</Color>
+  <Color x:Key="ColorCorePurple800">#FF5E4EBA</Color>
+  <Color x:Key="ColorCorePurple900">#FF483A9C</Color>
+  <Color x:Key="ColorCorePurple1000">#FF2D246B</Color>
+  <Color x:Key="ColorCorePurple1100">#FF1D1D38</Color>
+  <Color x:Key="ColorCoreMagenta0">#FFFEF0FF</Color>
+  <Color x:Key="ColorCoreMagenta100">#FFF9E3FC</Color>
+  <Color x:Key="ColorCoreMagenta200">#FFF4C4F7</Color>
+  <Color x:Key="ColorCoreMagenta300">#FFEDADF2</Color>
+  <Color x:Key="ColorCoreMagenta400">#FFF282F5</Color>
+  <Color x:Key="ColorCoreMagenta500">#FFDB61DB</Color>
+  <Color x:Key="ColorCoreMagenta600">#FFC44EB9</Color>
+  <Color x:Key="ColorCoreMagenta700">#FFAC44A8</Color>
+  <Color x:Key="ColorCoreMagenta800">#FF8F3896</Color>
+  <Color x:Key="ColorCoreMagenta900">#FF6C2277</Color>
+  <Color x:Key="ColorCoreMagenta1000">#FF451551</Color>
+  <Color x:Key="ColorCoreMagenta1100">#FF29192D</Color>
+  <Color x:Key="ColorCorePink0">#FFFFE9F3</Color>
+  <Color x:Key="ColorCorePink100">#FFFCDBEB</Color>
+  <Color x:Key="ColorCorePink200">#FFFFB5D5</Color>
+  <Color x:Key="ColorCorePink300">#FFFF95C1</Color>
+  <Color x:Key="ColorCorePink400">#FFFF76AE</Color>
+  <Color x:Key="ColorCorePink500">#FFEF588B</Color>
+  <Color x:Key="ColorCorePink600">#FFE0447C</Color>
+  <Color x:Key="ColorCorePink700">#FFCE3665</Color>
+  <Color x:Key="ColorCorePink800">#FFB22F5B</Color>
+  <Color x:Key="ColorCorePink900">#FF931847</Color>
+  <Color x:Key="ColorCorePink1000">#FF561231</Color>
+  <Color x:Key="ColorCorePink1100">#FF2B1721</Color>
+  <Color x:Key="ColorCoreRed0">#FFFFEAE9</Color>
+  <Color x:Key="ColorCoreRed100">#FFFFD5D2</Color>
+  <Color x:Key="ColorCoreRed200">#FFFFB8B1</Color>
+  <Color x:Key="ColorCoreRed300">#FFFF9C8F</Color>
+  <Color x:Key="ColorCoreRed400">#FFFF7F6E</Color>
+  <Color x:Key="ColorCoreRed500">#FFF76054</Color>
+  <Color x:Key="ColorCoreRed600">#FFED4C42</Color>
+  <Color x:Key="ColorCoreRed700">#FFDB3E3E</Color>
+  <Color x:Key="ColorCoreRed800">#FFC63434</Color>
+  <Color x:Key="ColorCoreRed900">#FF992222</Color>
+  <Color x:Key="ColorCoreRed1000">#FF6D1313</Color>
+  <Color x:Key="ColorCoreRed1100">#FF2B1111</Color>
+  <Color x:Key="ColorCoreOrange0">#FFFFEDE3</Color>
+  <Color x:Key="ColorCoreOrange100">#FFFCDCCC</Color>
+  <Color x:Key="ColorCoreOrange200">#FFFFC6A4</Color>
+  <Color x:Key="ColorCoreOrange300">#FFFFB180</Color>
+  <Color x:Key="ColorCoreOrange400">#FFFF9C5D</Color>
+  <Color x:Key="ColorCoreOrange500">#FFFC8943</Color>
+  <Color x:Key="ColorCoreOrange600">#FFF57D33</Color>
+  <Color x:Key="ColorCoreOrange700">#FFED7024</Color>
+  <Color x:Key="ColorCoreOrange800">#FFCE5511</Color>
+  <Color x:Key="ColorCoreOrange900">#FF962C0B</Color>
+  <Color x:Key="ColorCoreOrange1000">#FF601700</Color>
+  <Color x:Key="ColorCoreOrange1100">#FF2D130E</Color>
+  <Color x:Key="ColorCoreNeutral0">#FFFFFFFF</Color>
+  <Color x:Key="ColorCoreNeutral100">#FFF3F4F4</Color>
+  <Color x:Key="ColorCoreNeutral200">#FFDEE1E1</Color>
+  <Color x:Key="ColorCoreNeutral300">#FFC8CCCC</Color>
+  <Color x:Key="ColorCoreNeutral400">#FFB0B6B7</Color>
+  <Color x:Key="ColorCoreNeutral500">#FF929A9B</Color>
+  <Color x:Key="ColorCoreNeutral600">#FF6E797A</Color>
+  <Color x:Key="ColorCoreNeutral700">#FF515E5F</Color>
+  <Color x:Key="ColorCoreNeutral800">#FF364141</Color>
+  <Color x:Key="ColorCoreNeutral900">#FF273333</Color>
+  <Color x:Key="ColorCoreNeutral1000">#FF162020</Color>
+  <Color x:Key="ColorCoreNeutral1100">#FF040404</Color>
+  <Color x:Key="ColorCoreYellow0">#FFFFF8E2</Color>
+  <Color x:Key="ColorCoreYellow100">#FFFDEFCD</Color>
+  <Color x:Key="ColorCoreYellow200">#FFFFE99A</Color>
+  <Color x:Key="ColorCoreYellow300">#FFFFE16E</Color>
+  <Color x:Key="ColorCoreYellow400">#FFFFD943</Color>
+  <Color x:Key="ColorCoreYellow500">#FFFFCD1C</Color>
+  <Color x:Key="ColorCoreYellow600">#FFFFBC00</Color>
+  <Color x:Key="ColorCoreYellow700">#FFDD9903</Color>
+  <Color x:Key="ColorCoreYellow800">#FFBA7506</Color>
+  <Color x:Key="ColorCoreYellow900">#FF944C0C</Color>
+  <Color x:Key="ColorCoreYellow1000">#FF542A00</Color>
+  <Color x:Key="ColorCoreYellow1100">#FF2D1A05</Color>
+  <x:Double x:Key="SizeBorderRadiusLarge">480.00</x:Double>
+  <x:Double x:Key="SizeBorderRadiusMedium">384.00</x:Double>
+  <x:Double x:Key="SizeBorderRadiusSmall">256.00</x:Double>
+  <x:Double x:Key="SizeFontSmall">12.00</x:Double>
+  <x:Double x:Key="SizeFontMedium">16.00</x:Double>
+  <x:Double x:Key="SizeFontLarge">24.00</x:Double>
+  <x:Double x:Key="SizeFontXl">36.00</x:Double>
+  <x:Double x:Key="SizePaddingSmall">8.00</x:Double>
+  <x:Double x:Key="SizePaddingMedium">16.00</x:Double>
+  <x:Double x:Key="SizePaddingLarge">16.00</x:Double>
+  <x:Double x:Key="SizePaddingXl">16.00</x:Double>
+  <StaticResource x:Key="ColorBackgroundPrimary" Key="ColorCoreNeutral0" />
+  <StaticResource x:Key="ColorBackgroundSecondary" Key="ColorCoreNeutral100" />
+  <StaticResource x:Key="ColorBackgroundTertiary" Key="ColorCoreNeutral200" />
+  <StaticResource x:Key="ColorBackgroundDanger" Key="ColorCoreRed0" />
+  <StaticResource x:Key="ColorBackgroundWarning" Key="ColorCoreOrange0" />
+  <StaticResource x:Key="ColorBackgroundSuccess" Key="ColorCoreGreen0" />
+  <StaticResource x:Key="ColorBackgroundInfo" Key="ColorCoreBlue0" />
+  <StaticResource x:Key="ColorBorderPrimary" Key="ColorCoreNeutral300" />
+  <StaticResource x:Key="ColorBrandPrimary" Key="ColorCoreAqua700" />
+  <StaticResource x:Key="ColorBrandSecondary" Key="ColorCorePurple700" />
+  <StaticResource x:Key="ColorFontPrimary" Key="ColorCoreNeutral1100" />
+  <StaticResource x:Key="ColorFontSecondary" Key="ColorCoreNeutral900" />
+  <StaticResource x:Key="ColorFontTertiary" Key="ColorCoreNeutral800" />
+  <StaticResource x:Key="ColorFontDanger" Key="ColorCoreRed1000" />
+  <StaticResource x:Key="ColorFontWarning" Key="ColorCoreOrange1000" />
+  <StaticResource x:Key="ColorFontSuccess" Key="ColorCoreGreen1000" />
+  <StaticResource x:Key="ColorBackgroundDisabled" Key="ColorBackgroundTertiary" />
+  <StaticResource x:Key="ColorFontInteractive" Key="ColorBrandPrimary" />
+  <StaticResource x:Key="ColorFontInteractiveHover" Key="ColorBrandPrimary" />
+  <StaticResource x:Key="ColorFontInteractiveActive" Key="ColorBrandSecondary" />
+  <StaticResource x:Key="ColorFontInteractiveDisabled" Key="ColorFontTertiary" />
+  <SolidColorBrush x:Key="ColorCoreGreen0Brush" Color="{StaticResource ColorCoreGreen0}" />
+  <SolidColorBrush x:Key="ColorCoreGreen100Brush" Color="{StaticResource ColorCoreGreen100}" />
+  <SolidColorBrush x:Key="ColorCoreGreen200Brush" Color="{StaticResource ColorCoreGreen200}" />
+  <SolidColorBrush x:Key="ColorCoreGreen300Brush" Color="{StaticResource ColorCoreGreen300}" />
+  <SolidColorBrush x:Key="ColorCoreGreen400Brush" Color="{StaticResource ColorCoreGreen400}" />
+  <SolidColorBrush x:Key="ColorCoreGreen500Brush" Color="{StaticResource ColorCoreGreen500}" />
+  <SolidColorBrush x:Key="ColorCoreGreen600Brush" Color="{StaticResource ColorCoreGreen600}" />
+  <SolidColorBrush x:Key="ColorCoreGreen700Brush" Color="{StaticResource ColorCoreGreen700}" />
+  <SolidColorBrush x:Key="ColorCoreGreen800Brush" Color="{StaticResource ColorCoreGreen800}" />
+  <SolidColorBrush x:Key="ColorCoreGreen900Brush" Color="{StaticResource ColorCoreGreen900}" />
+  <SolidColorBrush x:Key="ColorCoreGreen1000Brush" Color="{StaticResource ColorCoreGreen1000}" />
+  <SolidColorBrush x:Key="ColorCoreGreen1100Brush" Color="{StaticResource ColorCoreGreen1100}" />
+  <SolidColorBrush x:Key="ColorCoreTeal0Brush" Color="{StaticResource ColorCoreTeal0}" />
+  <SolidColorBrush x:Key="ColorCoreTeal100Brush" Color="{StaticResource ColorCoreTeal100}" />
+  <SolidColorBrush x:Key="ColorCoreTeal200Brush" Color="{StaticResource ColorCoreTeal200}" />
+  <SolidColorBrush x:Key="ColorCoreTeal300Brush" Color="{StaticResource ColorCoreTeal300}" />
+  <SolidColorBrush x:Key="ColorCoreTeal400Brush" Color="{StaticResource ColorCoreTeal400}" />
+  <SolidColorBrush x:Key="ColorCoreTeal500Brush" Color="{StaticResource ColorCoreTeal500}" />
+  <SolidColorBrush x:Key="ColorCoreTeal600Brush" Color="{StaticResource ColorCoreTeal600}" />
+  <SolidColorBrush x:Key="ColorCoreTeal700Brush" Color="{StaticResource ColorCoreTeal700}" />
+  <SolidColorBrush x:Key="ColorCoreTeal800Brush" Color="{StaticResource ColorCoreTeal800}" />
+  <SolidColorBrush x:Key="ColorCoreTeal900Brush" Color="{StaticResource ColorCoreTeal900}" />
+  <SolidColorBrush x:Key="ColorCoreTeal1000Brush" Color="{StaticResource ColorCoreTeal1000}" />
+  <SolidColorBrush x:Key="ColorCoreTeal1100Brush" Color="{StaticResource ColorCoreTeal1100}" />
+  <SolidColorBrush x:Key="ColorCoreAqua0Brush" Color="{StaticResource ColorCoreAqua0}" />
+  <SolidColorBrush x:Key="ColorCoreAqua100Brush" Color="{StaticResource ColorCoreAqua100}" />
+  <SolidColorBrush x:Key="ColorCoreAqua200Brush" Color="{StaticResource ColorCoreAqua200}" />
+  <SolidColorBrush x:Key="ColorCoreAqua300Brush" Color="{StaticResource ColorCoreAqua300}" />
+  <SolidColorBrush x:Key="ColorCoreAqua400Brush" Color="{StaticResource ColorCoreAqua400}" />
+  <SolidColorBrush x:Key="ColorCoreAqua500Brush" Color="{StaticResource ColorCoreAqua500}" />
+  <SolidColorBrush x:Key="ColorCoreAqua600Brush" Color="{StaticResource ColorCoreAqua600}" />
+  <SolidColorBrush x:Key="ColorCoreAqua700Brush" Color="{StaticResource ColorCoreAqua700}" />
+  <SolidColorBrush x:Key="ColorCoreAqua800Brush" Color="{StaticResource ColorCoreAqua800}" />
+  <SolidColorBrush x:Key="ColorCoreAqua900Brush" Color="{StaticResource ColorCoreAqua900}" />
+  <SolidColorBrush x:Key="ColorCoreAqua1000Brush" Color="{StaticResource ColorCoreAqua1000}" />
+  <SolidColorBrush x:Key="ColorCoreAqua1100Brush" Color="{StaticResource ColorCoreAqua1100}" />
+  <SolidColorBrush x:Key="ColorCoreBlue0Brush" Color="{StaticResource ColorCoreBlue0}" />
+  <SolidColorBrush x:Key="ColorCoreBlue100Brush" Color="{StaticResource ColorCoreBlue100}" />
+  <SolidColorBrush x:Key="ColorCoreBlue200Brush" Color="{StaticResource ColorCoreBlue200}" />
+  <SolidColorBrush x:Key="ColorCoreBlue300Brush" Color="{StaticResource ColorCoreBlue300}" />
+  <SolidColorBrush x:Key="ColorCoreBlue400Brush" Color="{StaticResource ColorCoreBlue400}" />
+  <SolidColorBrush x:Key="ColorCoreBlue500Brush" Color="{StaticResource ColorCoreBlue500}" />
+  <SolidColorBrush x:Key="ColorCoreBlue600Brush" Color="{StaticResource ColorCoreBlue600}" />
+  <SolidColorBrush x:Key="ColorCoreBlue700Brush" Color="{StaticResource ColorCoreBlue700}" />
+  <SolidColorBrush x:Key="ColorCoreBlue800Brush" Color="{StaticResource ColorCoreBlue800}" />
+  <SolidColorBrush x:Key="ColorCoreBlue900Brush" Color="{StaticResource ColorCoreBlue900}" />
+  <SolidColorBrush x:Key="ColorCoreBlue1000Brush" Color="{StaticResource ColorCoreBlue1000}" />
+  <SolidColorBrush x:Key="ColorCoreBlue1100Brush" Color="{StaticResource ColorCoreBlue1100}" />
+  <SolidColorBrush x:Key="ColorCorePurple0Brush" Color="{StaticResource ColorCorePurple0}" />
+  <SolidColorBrush x:Key="ColorCorePurple100Brush" Color="{StaticResource ColorCorePurple100}" />
+  <SolidColorBrush x:Key="ColorCorePurple200Brush" Color="{StaticResource ColorCorePurple200}" />
+  <SolidColorBrush x:Key="ColorCorePurple300Brush" Color="{StaticResource ColorCorePurple300}" />
+  <SolidColorBrush x:Key="ColorCorePurple400Brush" Color="{StaticResource ColorCorePurple400}" />
+  <SolidColorBrush x:Key="ColorCorePurple500Brush" Color="{StaticResource ColorCorePurple500}" />
+  <SolidColorBrush x:Key="ColorCorePurple600Brush" Color="{StaticResource ColorCorePurple600}" />
+  <SolidColorBrush x:Key="ColorCorePurple700Brush" Color="{StaticResource ColorCorePurple700}" />
+  <SolidColorBrush x:Key="ColorCorePurple800Brush" Color="{StaticResource ColorCorePurple800}" />
+  <SolidColorBrush x:Key="ColorCorePurple900Brush" Color="{StaticResource ColorCorePurple900}" />
+  <SolidColorBrush x:Key="ColorCorePurple1000Brush" Color="{StaticResource ColorCorePurple1000}" />
+  <SolidColorBrush x:Key="ColorCorePurple1100Brush" Color="{StaticResource ColorCorePurple1100}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta0Brush" Color="{StaticResource ColorCoreMagenta0}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta100Brush" Color="{StaticResource ColorCoreMagenta100}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta200Brush" Color="{StaticResource ColorCoreMagenta200}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta300Brush" Color="{StaticResource ColorCoreMagenta300}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta400Brush" Color="{StaticResource ColorCoreMagenta400}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta500Brush" Color="{StaticResource ColorCoreMagenta500}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta600Brush" Color="{StaticResource ColorCoreMagenta600}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta700Brush" Color="{StaticResource ColorCoreMagenta700}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta800Brush" Color="{StaticResource ColorCoreMagenta800}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta900Brush" Color="{StaticResource ColorCoreMagenta900}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta1000Brush" Color="{StaticResource ColorCoreMagenta1000}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta1100Brush" Color="{StaticResource ColorCoreMagenta1100}" />
+  <SolidColorBrush x:Key="ColorCorePink0Brush" Color="{StaticResource ColorCorePink0}" />
+  <SolidColorBrush x:Key="ColorCorePink100Brush" Color="{StaticResource ColorCorePink100}" />
+  <SolidColorBrush x:Key="ColorCorePink200Brush" Color="{StaticResource ColorCorePink200}" />
+  <SolidColorBrush x:Key="ColorCorePink300Brush" Color="{StaticResource ColorCorePink300}" />
+  <SolidColorBrush x:Key="ColorCorePink400Brush" Color="{StaticResource ColorCorePink400}" />
+  <SolidColorBrush x:Key="ColorCorePink500Brush" Color="{StaticResource ColorCorePink500}" />
+  <SolidColorBrush x:Key="ColorCorePink600Brush" Color="{StaticResource ColorCorePink600}" />
+  <SolidColorBrush x:Key="ColorCorePink700Brush" Color="{StaticResource ColorCorePink700}" />
+  <SolidColorBrush x:Key="ColorCorePink800Brush" Color="{StaticResource ColorCorePink800}" />
+  <SolidColorBrush x:Key="ColorCorePink900Brush" Color="{StaticResource ColorCorePink900}" />
+  <SolidColorBrush x:Key="ColorCorePink1000Brush" Color="{StaticResource ColorCorePink1000}" />
+  <SolidColorBrush x:Key="ColorCorePink1100Brush" Color="{StaticResource ColorCorePink1100}" />
+  <SolidColorBrush x:Key="ColorCoreRed0Brush" Color="{StaticResource ColorCoreRed0}" />
+  <SolidColorBrush x:Key="ColorCoreRed100Brush" Color="{StaticResource ColorCoreRed100}" />
+  <SolidColorBrush x:Key="ColorCoreRed200Brush" Color="{StaticResource ColorCoreRed200}" />
+  <SolidColorBrush x:Key="ColorCoreRed300Brush" Color="{StaticResource ColorCoreRed300}" />
+  <SolidColorBrush x:Key="ColorCoreRed400Brush" Color="{StaticResource ColorCoreRed400}" />
+  <SolidColorBrush x:Key="ColorCoreRed500Brush" Color="{StaticResource ColorCoreRed500}" />
+  <SolidColorBrush x:Key="ColorCoreRed600Brush" Color="{StaticResource ColorCoreRed600}" />
+  <SolidColorBrush x:Key="ColorCoreRed700Brush" Color="{StaticResource ColorCoreRed700}" />
+  <SolidColorBrush x:Key="ColorCoreRed800Brush" Color="{StaticResource ColorCoreRed800}" />
+  <SolidColorBrush x:Key="ColorCoreRed900Brush" Color="{StaticResource ColorCoreRed900}" />
+  <SolidColorBrush x:Key="ColorCoreRed1000Brush" Color="{StaticResource ColorCoreRed1000}" />
+  <SolidColorBrush x:Key="ColorCoreRed1100Brush" Color="{StaticResource ColorCoreRed1100}" />
+  <SolidColorBrush x:Key="ColorCoreOrange0Brush" Color="{StaticResource ColorCoreOrange0}" />
+  <SolidColorBrush x:Key="ColorCoreOrange100Brush" Color="{StaticResource ColorCoreOrange100}" />
+  <SolidColorBrush x:Key="ColorCoreOrange200Brush" Color="{StaticResource ColorCoreOrange200}" />
+  <SolidColorBrush x:Key="ColorCoreOrange300Brush" Color="{StaticResource ColorCoreOrange300}" />
+  <SolidColorBrush x:Key="ColorCoreOrange400Brush" Color="{StaticResource ColorCoreOrange400}" />
+  <SolidColorBrush x:Key="ColorCoreOrange500Brush" Color="{StaticResource ColorCoreOrange500}" />
+  <SolidColorBrush x:Key="ColorCoreOrange600Brush" Color="{StaticResource ColorCoreOrange600}" />
+  <SolidColorBrush x:Key="ColorCoreOrange700Brush" Color="{StaticResource ColorCoreOrange700}" />
+  <SolidColorBrush x:Key="ColorCoreOrange800Brush" Color="{StaticResource ColorCoreOrange800}" />
+  <SolidColorBrush x:Key="ColorCoreOrange900Brush" Color="{StaticResource ColorCoreOrange900}" />
+  <SolidColorBrush x:Key="ColorCoreOrange1000Brush" Color="{StaticResource ColorCoreOrange1000}" />
+  <SolidColorBrush x:Key="ColorCoreOrange1100Brush" Color="{StaticResource ColorCoreOrange1100}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral0Brush" Color="{StaticResource ColorCoreNeutral0}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral100Brush" Color="{StaticResource ColorCoreNeutral100}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral200Brush" Color="{StaticResource ColorCoreNeutral200}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral300Brush" Color="{StaticResource ColorCoreNeutral300}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral400Brush" Color="{StaticResource ColorCoreNeutral400}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral500Brush" Color="{StaticResource ColorCoreNeutral500}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral600Brush" Color="{StaticResource ColorCoreNeutral600}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral700Brush" Color="{StaticResource ColorCoreNeutral700}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral800Brush" Color="{StaticResource ColorCoreNeutral800}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral900Brush" Color="{StaticResource ColorCoreNeutral900}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral1000Brush" Color="{StaticResource ColorCoreNeutral1000}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral1100Brush" Color="{StaticResource ColorCoreNeutral1100}" />
+  <SolidColorBrush x:Key="ColorCoreYellow0Brush" Color="{StaticResource ColorCoreYellow0}" />
+  <SolidColorBrush x:Key="ColorCoreYellow100Brush" Color="{StaticResource ColorCoreYellow100}" />
+  <SolidColorBrush x:Key="ColorCoreYellow200Brush" Color="{StaticResource ColorCoreYellow200}" />
+  <SolidColorBrush x:Key="ColorCoreYellow300Brush" Color="{StaticResource ColorCoreYellow300}" />
+  <SolidColorBrush x:Key="ColorCoreYellow400Brush" Color="{StaticResource ColorCoreYellow400}" />
+  <SolidColorBrush x:Key="ColorCoreYellow500Brush" Color="{StaticResource ColorCoreYellow500}" />
+  <SolidColorBrush x:Key="ColorCoreYellow600Brush" Color="{StaticResource ColorCoreYellow600}" />
+  <SolidColorBrush x:Key="ColorCoreYellow700Brush" Color="{StaticResource ColorCoreYellow700}" />
+  <SolidColorBrush x:Key="ColorCoreYellow800Brush" Color="{StaticResource ColorCoreYellow800}" />
+  <SolidColorBrush x:Key="ColorCoreYellow900Brush" Color="{StaticResource ColorCoreYellow900}" />
+  <SolidColorBrush x:Key="ColorCoreYellow1000Brush" Color="{StaticResource ColorCoreYellow1000}" />
+  <SolidColorBrush x:Key="ColorCoreYellow1100Brush" Color="{StaticResource ColorCoreYellow1100}" />
+  <SolidColorBrush x:Key="ColorBackgroundPrimaryBrush" Color="{StaticResource ColorBackgroundPrimary}" />
+  <SolidColorBrush x:Key="ColorBackgroundSecondaryBrush" Color="{StaticResource ColorBackgroundSecondary}" />
+  <SolidColorBrush x:Key="ColorBackgroundTertiaryBrush" Color="{StaticResource ColorBackgroundTertiary}" />
+  <SolidColorBrush x:Key="ColorBackgroundDangerBrush" Color="{StaticResource ColorBackgroundDanger}" />
+  <SolidColorBrush x:Key="ColorBackgroundWarningBrush" Color="{StaticResource ColorBackgroundWarning}" />
+  <SolidColorBrush x:Key="ColorBackgroundSuccessBrush" Color="{StaticResource ColorBackgroundSuccess}" />
+  <SolidColorBrush x:Key="ColorBackgroundInfoBrush" Color="{StaticResource ColorBackgroundInfo}" />
+  <SolidColorBrush x:Key="ColorBorderPrimaryBrush" Color="{StaticResource ColorBorderPrimary}" />
+  <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{StaticResource ColorBrandPrimary}" />
+  <SolidColorBrush x:Key="ColorBrandSecondaryBrush" Color="{StaticResource ColorBrandSecondary}" />
+  <SolidColorBrush x:Key="ColorFontPrimaryBrush" Color="{StaticResource ColorFontPrimary}" />
+  <SolidColorBrush x:Key="ColorFontSecondaryBrush" Color="{StaticResource ColorFontSecondary}" />
+  <SolidColorBrush x:Key="ColorFontTertiaryBrush" Color="{StaticResource ColorFontTertiary}" />
+  <SolidColorBrush x:Key="ColorFontDangerBrush" Color="{StaticResource ColorFontDanger}" />
+  <SolidColorBrush x:Key="ColorFontWarningBrush" Color="{StaticResource ColorFontWarning}" />
+  <SolidColorBrush x:Key="ColorFontSuccessBrush" Color="{StaticResource ColorFontSuccess}" />
+  <SolidColorBrush x:Key="ColorBackgroundDisabledBrush" Color="{StaticResource ColorBackgroundDisabled}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveBrush" Color="{StaticResource ColorFontInteractive}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveHoverBrush" Color="{StaticResource ColorFontInteractiveHover}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveActiveBrush" Color="{StaticResource ColorFontInteractiveActive}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveDisabledBrush" Color="{StaticResource ColorFontInteractiveDisabled}" />
+</ResourceDictionary>
+`;
+/* end snapshot integration xaml xaml/resourceDictionary with references should match snapshot */
+
+snapshots["integration xaml xaml/resourceDictionary with filter should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Color x:Key="ColorBackgroundPrimary">#FFFFFFFF</Color>
+  <Color x:Key="ColorBackgroundSecondary">#FFF3F4F4</Color>
+  <Color x:Key="ColorBackgroundTertiary">#FFDEE1E1</Color>
+  <Color x:Key="ColorBackgroundDanger">#FFFFEAE9</Color>
+  <Color x:Key="ColorBackgroundWarning">#FFFFEDE3</Color>
+  <Color x:Key="ColorBackgroundSuccess">#FFEBF9EB</Color>
+  <Color x:Key="ColorBackgroundInfo">#FFE9F8FF</Color>
+  <Color x:Key="ColorBackgroundDisabled">#FFDEE1E1</Color>
+  <Color x:Key="ColorBorderPrimary">#FFC8CCCC</Color>
+  <Color x:Key="ColorBrandPrimary">#FF0B8599</Color>
+  <Color x:Key="ColorBrandSecondary">#FF6F5ED3</Color>
+  <Color x:Key="ColorCoreGreen0">#FFEBF9EB</Color>
+  <Color x:Key="ColorCoreGreen100">#FFD7F4D7</Color>
+  <Color x:Key="ColorCoreGreen200">#FFC2F2BD</Color>
+  <Color x:Key="ColorCoreGreen300">#FF98E58E</Color>
+  <Color x:Key="ColorCoreGreen400">#FF75DD66</Color>
+  <Color x:Key="ColorCoreGreen500">#FF59CB59</Color>
+  <Color x:Key="ColorCoreGreen600">#FF2BB656</Color>
+  <Color x:Key="ColorCoreGreen700">#FF0CA750</Color>
+  <Color x:Key="ColorCoreGreen800">#FF008B46</Color>
+  <Color x:Key="ColorCoreGreen900">#FF006B40</Color>
+  <Color x:Key="ColorCoreGreen1000">#FF08422F</Color>
+  <Color x:Key="ColorCoreGreen1100">#FF002B20</Color>
+  <Color x:Key="ColorCoreTeal0">#FFE5F9F5</Color>
+  <Color x:Key="ColorCoreTeal100">#FFCDF7EF</Color>
+  <Color x:Key="ColorCoreTeal200">#FFB3F2E6</Color>
+  <Color x:Key="ColorCoreTeal300">#FF7DEAD5</Color>
+  <Color x:Key="ColorCoreTeal400">#FF24E0C5</Color>
+  <Color x:Key="ColorCoreTeal500">#FF08C4B2</Color>
+  <Color x:Key="ColorCoreTeal600">#FF00A99C</Color>
+  <Color x:Key="ColorCoreTeal700">#FF0B968F</Color>
+  <Color x:Key="ColorCoreTeal800">#FF067C7C</Color>
+  <Color x:Key="ColorCoreTeal900">#FF026661</Color>
+  <Color x:Key="ColorCoreTeal1000">#FF083F3F</Color>
+  <Color x:Key="ColorCoreTeal1100">#FF002528</Color>
+  <Color x:Key="ColorCoreAqua0">#FFD9FCFB</Color>
+  <Color x:Key="ColorCoreAqua100">#FFC5F9F9</Color>
+  <Color x:Key="ColorCoreAqua200">#FFA5F2F2</Color>
+  <Color x:Key="ColorCoreAqua300">#FF76E5E2</Color>
+  <Color x:Key="ColorCoreAqua400">#FF33D6E2</Color>
+  <Color x:Key="ColorCoreAqua500">#FF17B8CE</Color>
+  <Color x:Key="ColorCoreAqua600">#FF0797AE</Color>
+  <Color x:Key="ColorCoreAqua700">#FF0B8599</Color>
+  <Color x:Key="ColorCoreAqua800">#FF0F6E84</Color>
+  <Color x:Key="ColorCoreAqua900">#FF035E73</Color>
+  <Color x:Key="ColorCoreAqua1000">#FF083D4F</Color>
+  <Color x:Key="ColorCoreAqua1100">#FF002838</Color>
+  <Color x:Key="ColorCoreBlue0">#FFE9F8FF</Color>
+  <Color x:Key="ColorCoreBlue100">#FFDCF2FF</Color>
+  <Color x:Key="ColorCoreBlue200">#FFC7E4F9</Color>
+  <Color x:Key="ColorCoreBlue300">#FFA1D2F8</Color>
+  <Color x:Key="ColorCoreBlue400">#FF56ADF5</Color>
+  <Color x:Key="ColorCoreBlue500">#FF3896E3</Color>
+  <Color x:Key="ColorCoreBlue600">#FF2B87D3</Color>
+  <Color x:Key="ColorCoreBlue700">#FF2079C3</Color>
+  <Color x:Key="ColorCoreBlue800">#FF116DAA</Color>
+  <Color x:Key="ColorCoreBlue900">#FF0C5689</Color>
+  <Color x:Key="ColorCoreBlue1000">#FF0A3960</Color>
+  <Color x:Key="ColorCoreBlue1100">#FF002138</Color>
+  <Color x:Key="ColorCorePurple0">#FFF2F2F9</Color>
+  <Color x:Key="ColorCorePurple100">#FFEAEAF9</Color>
+  <Color x:Key="ColorCorePurple200">#FFD8D7F9</Color>
+  <Color x:Key="ColorCorePurple300">#FFC1C1F7</Color>
+  <Color x:Key="ColorCorePurple400">#FFA193F2</Color>
+  <Color x:Key="ColorCorePurple500">#FF9180F4</Color>
+  <Color x:Key="ColorCorePurple600">#FF816FEA</Color>
+  <Color x:Key="ColorCorePurple700">#FF6F5ED3</Color>
+  <Color x:Key="ColorCorePurple800">#FF5E4EBA</Color>
+  <Color x:Key="ColorCorePurple900">#FF483A9C</Color>
+  <Color x:Key="ColorCorePurple1000">#FF2D246B</Color>
+  <Color x:Key="ColorCorePurple1100">#FF1D1D38</Color>
+  <Color x:Key="ColorCoreMagenta0">#FFFEF0FF</Color>
+  <Color x:Key="ColorCoreMagenta100">#FFF9E3FC</Color>
+  <Color x:Key="ColorCoreMagenta200">#FFF4C4F7</Color>
+  <Color x:Key="ColorCoreMagenta300">#FFEDADF2</Color>
+  <Color x:Key="ColorCoreMagenta400">#FFF282F5</Color>
+  <Color x:Key="ColorCoreMagenta500">#FFDB61DB</Color>
+  <Color x:Key="ColorCoreMagenta600">#FFC44EB9</Color>
+  <Color x:Key="ColorCoreMagenta700">#FFAC44A8</Color>
+  <Color x:Key="ColorCoreMagenta800">#FF8F3896</Color>
+  <Color x:Key="ColorCoreMagenta900">#FF6C2277</Color>
+  <Color x:Key="ColorCoreMagenta1000">#FF451551</Color>
+  <Color x:Key="ColorCoreMagenta1100">#FF29192D</Color>
+  <Color x:Key="ColorCorePink0">#FFFFE9F3</Color>
+  <Color x:Key="ColorCorePink100">#FFFCDBEB</Color>
+  <Color x:Key="ColorCorePink200">#FFFFB5D5</Color>
+  <Color x:Key="ColorCorePink300">#FFFF95C1</Color>
+  <Color x:Key="ColorCorePink400">#FFFF76AE</Color>
+  <Color x:Key="ColorCorePink500">#FFEF588B</Color>
+  <Color x:Key="ColorCorePink600">#FFE0447C</Color>
+  <Color x:Key="ColorCorePink700">#FFCE3665</Color>
+  <Color x:Key="ColorCorePink800">#FFB22F5B</Color>
+  <Color x:Key="ColorCorePink900">#FF931847</Color>
+  <Color x:Key="ColorCorePink1000">#FF561231</Color>
+  <Color x:Key="ColorCorePink1100">#FF2B1721</Color>
+  <Color x:Key="ColorCoreRed0">#FFFFEAE9</Color>
+  <Color x:Key="ColorCoreRed100">#FFFFD5D2</Color>
+  <Color x:Key="ColorCoreRed200">#FFFFB8B1</Color>
+  <Color x:Key="ColorCoreRed300">#FFFF9C8F</Color>
+  <Color x:Key="ColorCoreRed400">#FFFF7F6E</Color>
+  <Color x:Key="ColorCoreRed500">#FFF76054</Color>
+  <Color x:Key="ColorCoreRed600">#FFED4C42</Color>
+  <Color x:Key="ColorCoreRed700">#FFDB3E3E</Color>
+  <Color x:Key="ColorCoreRed800">#FFC63434</Color>
+  <Color x:Key="ColorCoreRed900">#FF992222</Color>
+  <Color x:Key="ColorCoreRed1000">#FF6D1313</Color>
+  <Color x:Key="ColorCoreRed1100">#FF2B1111</Color>
+  <Color x:Key="ColorCoreOrange0">#FFFFEDE3</Color>
+  <Color x:Key="ColorCoreOrange100">#FFFCDCCC</Color>
+  <Color x:Key="ColorCoreOrange200">#FFFFC6A4</Color>
+  <Color x:Key="ColorCoreOrange300">#FFFFB180</Color>
+  <Color x:Key="ColorCoreOrange400">#FFFF9C5D</Color>
+  <Color x:Key="ColorCoreOrange500">#FFFC8943</Color>
+  <Color x:Key="ColorCoreOrange600">#FFF57D33</Color>
+  <Color x:Key="ColorCoreOrange700">#FFED7024</Color>
+  <Color x:Key="ColorCoreOrange800">#FFCE5511</Color>
+  <Color x:Key="ColorCoreOrange900">#FF962C0B</Color>
+  <Color x:Key="ColorCoreOrange1000">#FF601700</Color>
+  <Color x:Key="ColorCoreOrange1100">#FF2D130E</Color>
+  <Color x:Key="ColorCoreNeutral0">#FFFFFFFF</Color>
+  <Color x:Key="ColorCoreNeutral100">#FFF3F4F4</Color>
+  <Color x:Key="ColorCoreNeutral200">#FFDEE1E1</Color>
+  <Color x:Key="ColorCoreNeutral300">#FFC8CCCC</Color>
+  <Color x:Key="ColorCoreNeutral400">#FFB0B6B7</Color>
+  <Color x:Key="ColorCoreNeutral500">#FF929A9B</Color>
+  <Color x:Key="ColorCoreNeutral600">#FF6E797A</Color>
+  <Color x:Key="ColorCoreNeutral700">#FF515E5F</Color>
+  <Color x:Key="ColorCoreNeutral800">#FF364141</Color>
+  <Color x:Key="ColorCoreNeutral900">#FF273333</Color>
+  <Color x:Key="ColorCoreNeutral1000">#FF162020</Color>
+  <Color x:Key="ColorCoreNeutral1100">#FF040404</Color>
+  <Color x:Key="ColorCoreYellow0">#FFFFF8E2</Color>
+  <Color x:Key="ColorCoreYellow100">#FFFDEFCD</Color>
+  <Color x:Key="ColorCoreYellow200">#FFFFE99A</Color>
+  <Color x:Key="ColorCoreYellow300">#FFFFE16E</Color>
+  <Color x:Key="ColorCoreYellow400">#FFFFD943</Color>
+  <Color x:Key="ColorCoreYellow500">#FFFFCD1C</Color>
+  <Color x:Key="ColorCoreYellow600">#FFFFBC00</Color>
+  <Color x:Key="ColorCoreYellow700">#FFDD9903</Color>
+  <Color x:Key="ColorCoreYellow800">#FFBA7506</Color>
+  <Color x:Key="ColorCoreYellow900">#FF944C0C</Color>
+  <Color x:Key="ColorCoreYellow1000">#FF542A00</Color>
+  <Color x:Key="ColorCoreYellow1100">#FF2D1A05</Color>
+  <Color x:Key="ColorFontPrimary">#FF040404</Color>
+  <Color x:Key="ColorFontSecondary">#FF273333</Color>
+  <Color x:Key="ColorFontTertiary">#FF364141</Color>
+  <Color x:Key="ColorFontInteractive">#FF0B8599</Color>
+  <Color x:Key="ColorFontInteractiveHover">#FF0B8599</Color>
+  <Color x:Key="ColorFontInteractiveActive">#FF6F5ED3</Color>
+  <Color x:Key="ColorFontInteractiveDisabled">#FF364141</Color>
+  <Color x:Key="ColorFontDanger">#FF6D1313</Color>
+  <Color x:Key="ColorFontWarning">#FF601700</Color>
+  <Color x:Key="ColorFontSuccess">#FF08422F</Color>
+  <SolidColorBrush x:Key="ColorBackgroundPrimaryBrush" Color="{StaticResource ColorBackgroundPrimary}" />
+  <SolidColorBrush x:Key="ColorBackgroundSecondaryBrush" Color="{StaticResource ColorBackgroundSecondary}" />
+  <SolidColorBrush x:Key="ColorBackgroundTertiaryBrush" Color="{StaticResource ColorBackgroundTertiary}" />
+  <SolidColorBrush x:Key="ColorBackgroundDangerBrush" Color="{StaticResource ColorBackgroundDanger}" />
+  <SolidColorBrush x:Key="ColorBackgroundWarningBrush" Color="{StaticResource ColorBackgroundWarning}" />
+  <SolidColorBrush x:Key="ColorBackgroundSuccessBrush" Color="{StaticResource ColorBackgroundSuccess}" />
+  <SolidColorBrush x:Key="ColorBackgroundInfoBrush" Color="{StaticResource ColorBackgroundInfo}" />
+  <SolidColorBrush x:Key="ColorBackgroundDisabledBrush" Color="{StaticResource ColorBackgroundDisabled}" />
+  <SolidColorBrush x:Key="ColorBorderPrimaryBrush" Color="{StaticResource ColorBorderPrimary}" />
+  <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{StaticResource ColorBrandPrimary}" />
+  <SolidColorBrush x:Key="ColorBrandSecondaryBrush" Color="{StaticResource ColorBrandSecondary}" />
+  <SolidColorBrush x:Key="ColorCoreGreen0Brush" Color="{StaticResource ColorCoreGreen0}" />
+  <SolidColorBrush x:Key="ColorCoreGreen100Brush" Color="{StaticResource ColorCoreGreen100}" />
+  <SolidColorBrush x:Key="ColorCoreGreen200Brush" Color="{StaticResource ColorCoreGreen200}" />
+  <SolidColorBrush x:Key="ColorCoreGreen300Brush" Color="{StaticResource ColorCoreGreen300}" />
+  <SolidColorBrush x:Key="ColorCoreGreen400Brush" Color="{StaticResource ColorCoreGreen400}" />
+  <SolidColorBrush x:Key="ColorCoreGreen500Brush" Color="{StaticResource ColorCoreGreen500}" />
+  <SolidColorBrush x:Key="ColorCoreGreen600Brush" Color="{StaticResource ColorCoreGreen600}" />
+  <SolidColorBrush x:Key="ColorCoreGreen700Brush" Color="{StaticResource ColorCoreGreen700}" />
+  <SolidColorBrush x:Key="ColorCoreGreen800Brush" Color="{StaticResource ColorCoreGreen800}" />
+  <SolidColorBrush x:Key="ColorCoreGreen900Brush" Color="{StaticResource ColorCoreGreen900}" />
+  <SolidColorBrush x:Key="ColorCoreGreen1000Brush" Color="{StaticResource ColorCoreGreen1000}" />
+  <SolidColorBrush x:Key="ColorCoreGreen1100Brush" Color="{StaticResource ColorCoreGreen1100}" />
+  <SolidColorBrush x:Key="ColorCoreTeal0Brush" Color="{StaticResource ColorCoreTeal0}" />
+  <SolidColorBrush x:Key="ColorCoreTeal100Brush" Color="{StaticResource ColorCoreTeal100}" />
+  <SolidColorBrush x:Key="ColorCoreTeal200Brush" Color="{StaticResource ColorCoreTeal200}" />
+  <SolidColorBrush x:Key="ColorCoreTeal300Brush" Color="{StaticResource ColorCoreTeal300}" />
+  <SolidColorBrush x:Key="ColorCoreTeal400Brush" Color="{StaticResource ColorCoreTeal400}" />
+  <SolidColorBrush x:Key="ColorCoreTeal500Brush" Color="{StaticResource ColorCoreTeal500}" />
+  <SolidColorBrush x:Key="ColorCoreTeal600Brush" Color="{StaticResource ColorCoreTeal600}" />
+  <SolidColorBrush x:Key="ColorCoreTeal700Brush" Color="{StaticResource ColorCoreTeal700}" />
+  <SolidColorBrush x:Key="ColorCoreTeal800Brush" Color="{StaticResource ColorCoreTeal800}" />
+  <SolidColorBrush x:Key="ColorCoreTeal900Brush" Color="{StaticResource ColorCoreTeal900}" />
+  <SolidColorBrush x:Key="ColorCoreTeal1000Brush" Color="{StaticResource ColorCoreTeal1000}" />
+  <SolidColorBrush x:Key="ColorCoreTeal1100Brush" Color="{StaticResource ColorCoreTeal1100}" />
+  <SolidColorBrush x:Key="ColorCoreAqua0Brush" Color="{StaticResource ColorCoreAqua0}" />
+  <SolidColorBrush x:Key="ColorCoreAqua100Brush" Color="{StaticResource ColorCoreAqua100}" />
+  <SolidColorBrush x:Key="ColorCoreAqua200Brush" Color="{StaticResource ColorCoreAqua200}" />
+  <SolidColorBrush x:Key="ColorCoreAqua300Brush" Color="{StaticResource ColorCoreAqua300}" />
+  <SolidColorBrush x:Key="ColorCoreAqua400Brush" Color="{StaticResource ColorCoreAqua400}" />
+  <SolidColorBrush x:Key="ColorCoreAqua500Brush" Color="{StaticResource ColorCoreAqua500}" />
+  <SolidColorBrush x:Key="ColorCoreAqua600Brush" Color="{StaticResource ColorCoreAqua600}" />
+  <SolidColorBrush x:Key="ColorCoreAqua700Brush" Color="{StaticResource ColorCoreAqua700}" />
+  <SolidColorBrush x:Key="ColorCoreAqua800Brush" Color="{StaticResource ColorCoreAqua800}" />
+  <SolidColorBrush x:Key="ColorCoreAqua900Brush" Color="{StaticResource ColorCoreAqua900}" />
+  <SolidColorBrush x:Key="ColorCoreAqua1000Brush" Color="{StaticResource ColorCoreAqua1000}" />
+  <SolidColorBrush x:Key="ColorCoreAqua1100Brush" Color="{StaticResource ColorCoreAqua1100}" />
+  <SolidColorBrush x:Key="ColorCoreBlue0Brush" Color="{StaticResource ColorCoreBlue0}" />
+  <SolidColorBrush x:Key="ColorCoreBlue100Brush" Color="{StaticResource ColorCoreBlue100}" />
+  <SolidColorBrush x:Key="ColorCoreBlue200Brush" Color="{StaticResource ColorCoreBlue200}" />
+  <SolidColorBrush x:Key="ColorCoreBlue300Brush" Color="{StaticResource ColorCoreBlue300}" />
+  <SolidColorBrush x:Key="ColorCoreBlue400Brush" Color="{StaticResource ColorCoreBlue400}" />
+  <SolidColorBrush x:Key="ColorCoreBlue500Brush" Color="{StaticResource ColorCoreBlue500}" />
+  <SolidColorBrush x:Key="ColorCoreBlue600Brush" Color="{StaticResource ColorCoreBlue600}" />
+  <SolidColorBrush x:Key="ColorCoreBlue700Brush" Color="{StaticResource ColorCoreBlue700}" />
+  <SolidColorBrush x:Key="ColorCoreBlue800Brush" Color="{StaticResource ColorCoreBlue800}" />
+  <SolidColorBrush x:Key="ColorCoreBlue900Brush" Color="{StaticResource ColorCoreBlue900}" />
+  <SolidColorBrush x:Key="ColorCoreBlue1000Brush" Color="{StaticResource ColorCoreBlue1000}" />
+  <SolidColorBrush x:Key="ColorCoreBlue1100Brush" Color="{StaticResource ColorCoreBlue1100}" />
+  <SolidColorBrush x:Key="ColorCorePurple0Brush" Color="{StaticResource ColorCorePurple0}" />
+  <SolidColorBrush x:Key="ColorCorePurple100Brush" Color="{StaticResource ColorCorePurple100}" />
+  <SolidColorBrush x:Key="ColorCorePurple200Brush" Color="{StaticResource ColorCorePurple200}" />
+  <SolidColorBrush x:Key="ColorCorePurple300Brush" Color="{StaticResource ColorCorePurple300}" />
+  <SolidColorBrush x:Key="ColorCorePurple400Brush" Color="{StaticResource ColorCorePurple400}" />
+  <SolidColorBrush x:Key="ColorCorePurple500Brush" Color="{StaticResource ColorCorePurple500}" />
+  <SolidColorBrush x:Key="ColorCorePurple600Brush" Color="{StaticResource ColorCorePurple600}" />
+  <SolidColorBrush x:Key="ColorCorePurple700Brush" Color="{StaticResource ColorCorePurple700}" />
+  <SolidColorBrush x:Key="ColorCorePurple800Brush" Color="{StaticResource ColorCorePurple800}" />
+  <SolidColorBrush x:Key="ColorCorePurple900Brush" Color="{StaticResource ColorCorePurple900}" />
+  <SolidColorBrush x:Key="ColorCorePurple1000Brush" Color="{StaticResource ColorCorePurple1000}" />
+  <SolidColorBrush x:Key="ColorCorePurple1100Brush" Color="{StaticResource ColorCorePurple1100}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta0Brush" Color="{StaticResource ColorCoreMagenta0}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta100Brush" Color="{StaticResource ColorCoreMagenta100}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta200Brush" Color="{StaticResource ColorCoreMagenta200}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta300Brush" Color="{StaticResource ColorCoreMagenta300}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta400Brush" Color="{StaticResource ColorCoreMagenta400}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta500Brush" Color="{StaticResource ColorCoreMagenta500}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta600Brush" Color="{StaticResource ColorCoreMagenta600}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta700Brush" Color="{StaticResource ColorCoreMagenta700}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta800Brush" Color="{StaticResource ColorCoreMagenta800}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta900Brush" Color="{StaticResource ColorCoreMagenta900}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta1000Brush" Color="{StaticResource ColorCoreMagenta1000}" />
+  <SolidColorBrush x:Key="ColorCoreMagenta1100Brush" Color="{StaticResource ColorCoreMagenta1100}" />
+  <SolidColorBrush x:Key="ColorCorePink0Brush" Color="{StaticResource ColorCorePink0}" />
+  <SolidColorBrush x:Key="ColorCorePink100Brush" Color="{StaticResource ColorCorePink100}" />
+  <SolidColorBrush x:Key="ColorCorePink200Brush" Color="{StaticResource ColorCorePink200}" />
+  <SolidColorBrush x:Key="ColorCorePink300Brush" Color="{StaticResource ColorCorePink300}" />
+  <SolidColorBrush x:Key="ColorCorePink400Brush" Color="{StaticResource ColorCorePink400}" />
+  <SolidColorBrush x:Key="ColorCorePink500Brush" Color="{StaticResource ColorCorePink500}" />
+  <SolidColorBrush x:Key="ColorCorePink600Brush" Color="{StaticResource ColorCorePink600}" />
+  <SolidColorBrush x:Key="ColorCorePink700Brush" Color="{StaticResource ColorCorePink700}" />
+  <SolidColorBrush x:Key="ColorCorePink800Brush" Color="{StaticResource ColorCorePink800}" />
+  <SolidColorBrush x:Key="ColorCorePink900Brush" Color="{StaticResource ColorCorePink900}" />
+  <SolidColorBrush x:Key="ColorCorePink1000Brush" Color="{StaticResource ColorCorePink1000}" />
+  <SolidColorBrush x:Key="ColorCorePink1100Brush" Color="{StaticResource ColorCorePink1100}" />
+  <SolidColorBrush x:Key="ColorCoreRed0Brush" Color="{StaticResource ColorCoreRed0}" />
+  <SolidColorBrush x:Key="ColorCoreRed100Brush" Color="{StaticResource ColorCoreRed100}" />
+  <SolidColorBrush x:Key="ColorCoreRed200Brush" Color="{StaticResource ColorCoreRed200}" />
+  <SolidColorBrush x:Key="ColorCoreRed300Brush" Color="{StaticResource ColorCoreRed300}" />
+  <SolidColorBrush x:Key="ColorCoreRed400Brush" Color="{StaticResource ColorCoreRed400}" />
+  <SolidColorBrush x:Key="ColorCoreRed500Brush" Color="{StaticResource ColorCoreRed500}" />
+  <SolidColorBrush x:Key="ColorCoreRed600Brush" Color="{StaticResource ColorCoreRed600}" />
+  <SolidColorBrush x:Key="ColorCoreRed700Brush" Color="{StaticResource ColorCoreRed700}" />
+  <SolidColorBrush x:Key="ColorCoreRed800Brush" Color="{StaticResource ColorCoreRed800}" />
+  <SolidColorBrush x:Key="ColorCoreRed900Brush" Color="{StaticResource ColorCoreRed900}" />
+  <SolidColorBrush x:Key="ColorCoreRed1000Brush" Color="{StaticResource ColorCoreRed1000}" />
+  <SolidColorBrush x:Key="ColorCoreRed1100Brush" Color="{StaticResource ColorCoreRed1100}" />
+  <SolidColorBrush x:Key="ColorCoreOrange0Brush" Color="{StaticResource ColorCoreOrange0}" />
+  <SolidColorBrush x:Key="ColorCoreOrange100Brush" Color="{StaticResource ColorCoreOrange100}" />
+  <SolidColorBrush x:Key="ColorCoreOrange200Brush" Color="{StaticResource ColorCoreOrange200}" />
+  <SolidColorBrush x:Key="ColorCoreOrange300Brush" Color="{StaticResource ColorCoreOrange300}" />
+  <SolidColorBrush x:Key="ColorCoreOrange400Brush" Color="{StaticResource ColorCoreOrange400}" />
+  <SolidColorBrush x:Key="ColorCoreOrange500Brush" Color="{StaticResource ColorCoreOrange500}" />
+  <SolidColorBrush x:Key="ColorCoreOrange600Brush" Color="{StaticResource ColorCoreOrange600}" />
+  <SolidColorBrush x:Key="ColorCoreOrange700Brush" Color="{StaticResource ColorCoreOrange700}" />
+  <SolidColorBrush x:Key="ColorCoreOrange800Brush" Color="{StaticResource ColorCoreOrange800}" />
+  <SolidColorBrush x:Key="ColorCoreOrange900Brush" Color="{StaticResource ColorCoreOrange900}" />
+  <SolidColorBrush x:Key="ColorCoreOrange1000Brush" Color="{StaticResource ColorCoreOrange1000}" />
+  <SolidColorBrush x:Key="ColorCoreOrange1100Brush" Color="{StaticResource ColorCoreOrange1100}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral0Brush" Color="{StaticResource ColorCoreNeutral0}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral100Brush" Color="{StaticResource ColorCoreNeutral100}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral200Brush" Color="{StaticResource ColorCoreNeutral200}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral300Brush" Color="{StaticResource ColorCoreNeutral300}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral400Brush" Color="{StaticResource ColorCoreNeutral400}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral500Brush" Color="{StaticResource ColorCoreNeutral500}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral600Brush" Color="{StaticResource ColorCoreNeutral600}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral700Brush" Color="{StaticResource ColorCoreNeutral700}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral800Brush" Color="{StaticResource ColorCoreNeutral800}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral900Brush" Color="{StaticResource ColorCoreNeutral900}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral1000Brush" Color="{StaticResource ColorCoreNeutral1000}" />
+  <SolidColorBrush x:Key="ColorCoreNeutral1100Brush" Color="{StaticResource ColorCoreNeutral1100}" />
+  <SolidColorBrush x:Key="ColorCoreYellow0Brush" Color="{StaticResource ColorCoreYellow0}" />
+  <SolidColorBrush x:Key="ColorCoreYellow100Brush" Color="{StaticResource ColorCoreYellow100}" />
+  <SolidColorBrush x:Key="ColorCoreYellow200Brush" Color="{StaticResource ColorCoreYellow200}" />
+  <SolidColorBrush x:Key="ColorCoreYellow300Brush" Color="{StaticResource ColorCoreYellow300}" />
+  <SolidColorBrush x:Key="ColorCoreYellow400Brush" Color="{StaticResource ColorCoreYellow400}" />
+  <SolidColorBrush x:Key="ColorCoreYellow500Brush" Color="{StaticResource ColorCoreYellow500}" />
+  <SolidColorBrush x:Key="ColorCoreYellow600Brush" Color="{StaticResource ColorCoreYellow600}" />
+  <SolidColorBrush x:Key="ColorCoreYellow700Brush" Color="{StaticResource ColorCoreYellow700}" />
+  <SolidColorBrush x:Key="ColorCoreYellow800Brush" Color="{StaticResource ColorCoreYellow800}" />
+  <SolidColorBrush x:Key="ColorCoreYellow900Brush" Color="{StaticResource ColorCoreYellow900}" />
+  <SolidColorBrush x:Key="ColorCoreYellow1000Brush" Color="{StaticResource ColorCoreYellow1000}" />
+  <SolidColorBrush x:Key="ColorCoreYellow1100Brush" Color="{StaticResource ColorCoreYellow1100}" />
+  <SolidColorBrush x:Key="ColorFontPrimaryBrush" Color="{StaticResource ColorFontPrimary}" />
+  <SolidColorBrush x:Key="ColorFontSecondaryBrush" Color="{StaticResource ColorFontSecondary}" />
+  <SolidColorBrush x:Key="ColorFontTertiaryBrush" Color="{StaticResource ColorFontTertiary}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveBrush" Color="{StaticResource ColorFontInteractive}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveHoverBrush" Color="{StaticResource ColorFontInteractiveHover}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveActiveBrush" Color="{StaticResource ColorFontInteractiveActive}" />
+  <SolidColorBrush x:Key="ColorFontInteractiveDisabledBrush" Color="{StaticResource ColorFontInteractiveDisabled}" />
+  <SolidColorBrush x:Key="ColorFontDangerBrush" Color="{StaticResource ColorFontDanger}" />
+  <SolidColorBrush x:Key="ColorFontWarningBrush" Color="{StaticResource ColorFontWarning}" />
+  <SolidColorBrush x:Key="ColorFontSuccessBrush" Color="{StaticResource ColorFontSuccess}" />
+</ResourceDictionary>
+`;
+/* end snapshot integration xaml xaml/resourceDictionary with filter should match snapshot */
+

--- a/__integration__/xaml.test.js
+++ b/__integration__/xaml.test.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import StyleDictionary from 'style-dictionary';
+import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
+import { buildPath } from './_constants.js';
+import { clearOutput } from '../__tests__/__helpers.js';
+import { formats, transforms } from 'style-dictionary/enums';
+
+const { xamlResourceDictionary } = formats;
+const { attributeCti, colorHex8android, namePascal, sizeRemToFloat } = transforms;
+
+describe('integration', async () => {
+  before(async () => {
+    const sd = new StyleDictionary({
+      source: [`__integration__/tokens/**/[!_]*.json?(c)`],
+      platforms: {
+        xaml: {
+          transforms: [attributeCti, namePascal, colorHex8android, sizeRemToFloat],
+          buildPath,
+          files: [
+            {
+              destination: 'Tokens.xaml',
+              format: xamlResourceDictionary,
+              options: {
+                outputColorBrushes: true,
+              },
+            },
+            {
+              destination: 'TokensWithReferences.xaml',
+              format: xamlResourceDictionary,
+              options: {
+                outputColorBrushes: true,
+                outputReferences: true,
+              },
+            },
+            {
+              destination: 'Colors.xaml',
+              format: xamlResourceDictionary,
+              filter: {
+                type: 'color',
+              },
+              options: {
+                outputColorBrushes: true,
+                resourceType: 'Color',
+              },
+            },
+          ],
+        },
+      },
+    });
+    await sd.buildAllPlatforms();
+  });
+
+  afterEach(() => {
+    clearOutput(buildPath);
+  });
+
+  describe('xaml', async () => {
+    describe(xamlResourceDictionary, async () => {
+      it(`should match snapshot`, async () => {
+        const output = fs.readFileSync(resolve(`${buildPath}Tokens.xaml`), {
+          encoding: 'UTF-8',
+        });
+        await expect(output).to.matchSnapshot();
+      });
+
+      describe(`with references`, async () => {
+        it(`should match snapshot`, async () => {
+          const output = fs.readFileSync(resolve(`${buildPath}TokensWithReferences.xaml`), {
+            encoding: 'UTF-8',
+          });
+          await expect(output).to.matchSnapshot();
+        });
+      });
+
+      describe(`with filter`, async () => {
+        it(`should match snapshot`, async () => {
+          const output = fs.readFileSync(resolve(`${buildPath}Colors.xaml`), {
+            encoding: 'UTF-8',
+          });
+          await expect(output).to.matchSnapshot();
+        });
+      });
+    });
+  });
+});

--- a/__tests__/common/formatHelpers/setXamlResourceDictionaryProperties.test.js
+++ b/__tests__/common/formatHelpers/setXamlResourceDictionaryProperties.test.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import setXamlResourceDictionaryProperties from '../../../lib/common/formatHelpers/setXamlResourceDictionaryProperties.js';
+
+describe('setXamlResourceDictionaryProperties', () => {
+  it('should set the default options', () => {
+    const options = setXamlResourceDictionaryProperties({});
+
+    expect(options.outputColorBrushes).to.equal(false);
+    expect(options.brushSuffix).to.equal('Brush');
+    expect(options.resourceReferenceType).to.equal('StaticResource');
+    expect(options.resourceTypeMap).to.deep.equal({
+      color: 'Color',
+      dimension: 'x:Double',
+      fontSize: 'x:Double',
+      number: 'x:Double',
+      string: 'x:String',
+      content: 'x:String',
+      boolean: 'x:Boolean',
+    });
+  });
+
+  it('should merge custom resource type map values', () => {
+    const options = setXamlResourceDictionaryProperties({
+      resourceTypeMap: {
+        dimension: 'x:Int32',
+        brandColor: 'Color',
+      },
+    });
+
+    expect(options.resourceTypeMap).to.deep.equal({
+      color: 'Color',
+      dimension: 'x:Int32',
+      fontSize: 'x:Double',
+      number: 'x:Double',
+      string: 'x:String',
+      content: 'x:String',
+      boolean: 'x:Boolean',
+      brandColor: 'Color',
+    });
+  });
+
+  it('should throw for invalid resourceReferenceType values', () => {
+    expect(() =>
+      setXamlResourceDictionaryProperties({
+        resourceReferenceType: 'InvalidResourceType',
+      }),
+    ).to.throw(
+      'xaml/resourceDictionary resourceReferenceType must be either "StaticResource" or "DynamicResource"',
+    );
+  });
+});

--- a/__tests__/formats/__snapshots__/all.test.snap.js
+++ b/__tests__/formats/__snapshots__/all.test.snap.js
@@ -1448,3 +1448,32 @@ class {
 }`;
 /* end snapshot formats all should match flutter/class.dart snapshot with fileHeaderTimestamp set */
 
+snapshots["formats all should match xaml/resourceDictionary snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <!-- comment -->
+  <Color x:Key="color_red">#FFFF0000</Color>
+</ResourceDictionary>
+`;
+/* end snapshot formats all should match xaml/resourceDictionary snapshot */
+
+snapshots["formats all should match xaml/resourceDictionary snapshot with fileHeaderTimestamp set"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+  Generated on Sat, 01 Jan 2000 00:00:00 GMT
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <!-- comment -->
+  <Color x:Key="color_red">#FFFF0000</Color>
+</ResourceDictionary>
+`;
+/* end snapshot formats all should match xaml/resourceDictionary snapshot with fileHeaderTimestamp set */
+

--- a/__tests__/formats/__snapshots__/xamlResourceDictionary.test.snap.js
+++ b/__tests__/formats/__snapshots__/xamlResourceDictionary.test.snap.js
@@ -1,0 +1,108 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["formats xaml/resourceDictionary should match default snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <!-- Brand primary color -->
+  <Color x:Key="ColorBrandPrimary">#FF0B8599</Color>
+  <x:Double x:Key="SizeCornerRadiusMedium">8</x:Double>
+  <x:Double x:Key="FontSizeBody">16</x:Double>
+  <x:String x:Key="GreetingText">Hello &amp; goodbye</x:String>
+  <x:Boolean x:Key="IsEnabled">True</x:Boolean>
+  <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{StaticResource ColorBrandPrimary}" />
+</ResourceDictionary>
+`;
+/* end snapshot formats xaml/resourceDictionary should match default snapshot */
+
+snapshots["formats xaml/resourceDictionary with options overrides should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  x:Class="MyApp.Resources.BrandTokens">
+  <Color x:Key="BrandPrimary">#FF663399</Color>
+  <SolidColorBrush x:Key="BrandPrimaryPaint" Color="{StaticResource BrandPrimary}" />
+</ResourceDictionary>
+`;
+/* end snapshot formats xaml/resourceDictionary with options overrides should match snapshot */
+
+snapshots["formats xaml/resourceDictionary with references should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Color x:Key="ColorBase">#FF0B8599</Color>
+  <x:Double x:Key="SizeBase">8</x:Double>
+  <StaticResource x:Key="ColorAlias" Key="ColorBase" />
+  <StaticResource x:Key="SizeAlias" Key="SizeBase" />
+  <SolidColorBrush x:Key="ColorBaseBrush" Color="{StaticResource ColorBase}" />
+  <SolidColorBrush x:Key="ColorAliasBrush" Color="{StaticResource ColorAlias}" />
+</ResourceDictionary>
+`;
+/* end snapshot formats xaml/resourceDictionary with references should match snapshot */
+
+snapshots["formats xaml/resourceDictionary with compatible primitive values should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <Color x:Key="ColorOverlay">#800B8599</Color>
+  <x:Single x:Key="StrokeWidth">12.5</x:Single>
+  <x:String x:Key="TaglineText">Use &lt;tag&gt; &amp; &quot;quotes&quot;</x:String>
+  <x:Boolean x:Key="IsPreview">False</x:Boolean>
+  <SolidColorBrush x:Key="ColorOverlayBrush" Color="{StaticResource ColorOverlay}" />
+</ResourceDictionary>
+`;
+/* end snapshot formats xaml/resourceDictionary with compatible primitive values should match snapshot */
+
+snapshots["formats xaml/resourceDictionary with a forced resource type should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <!-- Brand primary color -->
+  <x:String x:Key="ColorBrandPrimary">#0B8599</x:String>
+  <x:String x:Key="SizeCornerRadiusMedium">8</x:String>
+  <x:String x:Key="FontSizeBody">16</x:String>
+  <x:String x:Key="GreetingText">Hello &amp; goodbye</x:String>
+  <x:String x:Key="IsEnabled">true</x:String>
+</ResourceDictionary>
+`;
+/* end snapshot formats xaml/resourceDictionary with a forced resource type should match snapshot */
+
+snapshots["formats xaml/resourceDictionary with DynamicResource brush references should match snapshot"] = 
+`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <!-- Brand primary color -->
+  <Color x:Key="ColorBrandPrimary">#FF0B8599</Color>
+  <x:Double x:Key="SizeCornerRadiusMedium">8</x:Double>
+  <x:Double x:Key="FontSizeBody">16</x:Double>
+  <x:String x:Key="GreetingText">Hello &amp; goodbye</x:String>
+  <x:Boolean x:Key="IsEnabled">True</x:Boolean>
+  <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{DynamicResource ColorBrandPrimary}" />
+</ResourceDictionary>
+`;
+/* end snapshot formats xaml/resourceDictionary with DynamicResource brush references should match snapshot */

--- a/__tests__/formats/xamlResourceDictionary.test.js
+++ b/__tests__/formats/xamlResourceDictionary.test.js
@@ -1,0 +1,366 @@
+import { expect } from 'chai';
+import formats from '../../lib/common/formats.js';
+import createFormatArgs from '../../lib/utils/createFormatArgs.js';
+import { convertTokenData } from '../../lib/utils/convertTokenData.js';
+import { formats as fileFormats } from '../../lib/enums/index.js';
+
+const { xamlResourceDictionary } = fileFormats;
+
+const format = formats[xamlResourceDictionary];
+const file = {
+  destination: 'Tokens.xaml',
+  format: xamlResourceDictionary,
+};
+
+const baseTokens = {
+  color: {
+    brandPrimary: {
+      value: '#0B8599',
+      type: 'color',
+      comment: 'Brand primary color',
+      original: {
+        value: '#0B8599',
+      },
+      name: 'ColorBrandPrimary',
+      path: ['color', 'brandPrimary'],
+    },
+  },
+  size: {
+    cornerRadiusMedium: {
+      value: 8,
+      type: 'dimension',
+      original: {
+        value: 8,
+      },
+      name: 'SizeCornerRadiusMedium',
+      path: ['size', 'cornerRadiusMedium'],
+    },
+  },
+  fontSize: {
+    body: {
+      value: 16,
+      type: 'fontSize',
+      original: {
+        value: 16,
+      },
+      name: 'FontSizeBody',
+      path: ['fontSize', 'body'],
+    },
+  },
+  content: {
+    greeting: {
+      value: 'Hello & goodbye',
+      type: 'string',
+      original: {
+        value: 'Hello & goodbye',
+      },
+      name: 'GreetingText',
+      path: ['content', 'greeting'],
+    },
+  },
+  flags: {
+    isEnabled: {
+      value: true,
+      type: 'boolean',
+      original: {
+        value: true,
+      },
+      name: 'IsEnabled',
+      path: ['flags', 'isEnabled'],
+    },
+  },
+};
+
+const customTypeTokens = {
+  brand: {
+    primary: {
+      value: '#663399',
+      type: 'brandColor',
+      original: {
+        value: '#663399',
+      },
+      name: 'BrandPrimary',
+      path: ['brand', 'primary'],
+    },
+  },
+};
+
+const compatiblePrimitiveTokens = {
+  color: {
+    overlay: {
+      value: 'rgba(11, 133, 153, 0.5)',
+      type: 'color',
+      original: {
+        value: 'rgba(11, 133, 153, 0.5)',
+      },
+      name: 'ColorOverlay',
+      path: ['color', 'overlay'],
+    },
+  },
+  number: {
+    strokeWidth: {
+      value: '12.5f',
+      type: 'number',
+      original: {
+        value: '12.5f',
+      },
+      name: 'StrokeWidth',
+      path: ['number', 'strokeWidth'],
+    },
+  },
+  content: {
+    tagline: {
+      value: 'Use <tag> & "quotes"',
+      type: 'content',
+      original: {
+        value: 'Use <tag> & "quotes"',
+      },
+      name: 'TaglineText',
+      path: ['content', 'tagline'],
+    },
+  },
+  flags: {
+    isPreview: {
+      value: 'false',
+      type: 'boolean',
+      original: {
+        value: 'false',
+      },
+      name: 'IsPreview',
+      path: ['flags', 'isPreview'],
+    },
+  },
+};
+
+const referenceTokens = {
+  color: {
+    base: {
+      value: '#0B8599',
+      type: 'color',
+      original: {
+        value: '#0B8599',
+      },
+      name: 'ColorBase',
+      path: ['color', 'base'],
+    },
+    alias: {
+      value: '#0B8599',
+      type: 'color',
+      original: {
+        value: '{color.base}',
+      },
+      name: 'ColorAlias',
+      path: ['color', 'alias'],
+    },
+  },
+  size: {
+    base: {
+      value: 8,
+      type: 'number',
+      original: {
+        value: 8,
+      },
+      name: 'SizeBase',
+      path: ['size', 'base'],
+    },
+    alias: {
+      value: 8,
+      type: 'number',
+      original: {
+        value: '{size.base}',
+      },
+      name: 'SizeAlias',
+      path: ['size', 'alias'],
+    },
+  },
+};
+
+describe('formats', () => {
+  describe(`xaml/resourceDictionary`, () => {
+    it('should match default snapshot', async () => {
+      const f = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: baseTokens,
+            allTokens: convertTokenData(baseTokens, { output: 'array' }),
+          },
+          file: {
+            ...file,
+            options: {
+              outputColorBrushes: true,
+            },
+          },
+          platform: {},
+        }),
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('with compatible primitive values should match snapshot', async () => {
+      const f = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: compatiblePrimitiveTokens,
+            allTokens: convertTokenData(compatiblePrimitiveTokens, { output: 'array' }),
+          },
+          file: {
+            ...file,
+            options: {
+              outputColorBrushes: true,
+              resourceTypeMap: {
+                number: 'x:Single',
+              },
+            },
+          },
+          platform: {},
+        }),
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('with a forced resource type should match snapshot', async () => {
+      const f = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: baseTokens,
+            allTokens: convertTokenData(baseTokens, { output: 'array' }),
+          },
+          file: {
+            ...file,
+            options: {
+              resourceType: 'x:String',
+            },
+          },
+          platform: {},
+        }),
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('with DynamicResource brush references should match snapshot', async () => {
+      const f = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: baseTokens,
+            allTokens: convertTokenData(baseTokens, { output: 'array' }),
+          },
+          file: {
+            ...file,
+            options: {
+              outputColorBrushes: true,
+              resourceReferenceType: 'DynamicResource',
+            },
+          },
+          platform: {},
+        }),
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('with options overrides should match snapshot', async () => {
+      const f = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: customTypeTokens,
+            allTokens: convertTokenData(customTypeTokens, { output: 'array' }),
+          },
+          file: {
+            ...file,
+            options: {
+              className: 'MyApp.Resources.BrandTokens',
+              outputColorBrushes: true,
+              brushSuffix: 'Paint',
+              resourceTypeMap: {
+                brandColor: 'Color',
+              },
+            },
+          },
+          platform: {},
+        }),
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('with references should match snapshot', async () => {
+      const allTokens = convertTokenData(referenceTokens, { output: 'array' });
+      const f = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: referenceTokens,
+            allTokens,
+            unfilteredTokens: referenceTokens,
+          },
+          file: {
+            ...file,
+            options: {
+              outputReferences: true,
+              outputColorBrushes: true,
+            },
+          },
+          platform: {},
+        }),
+      );
+      await expect(f).to.matchSnapshot();
+    });
+
+    it('should throw for DynamicResource aliases', async () => {
+      const allTokens = convertTokenData(referenceTokens, { output: 'array' });
+
+      await expect(
+        format(
+          createFormatArgs({
+            dictionary: {
+              tokens: referenceTokens,
+              allTokens,
+              unfilteredTokens: referenceTokens,
+            },
+            file: {
+              ...file,
+              options: {
+                outputReferences: true,
+                resourceReferenceType: 'DynamicResource',
+              },
+            },
+            platform: {},
+          }),
+        ),
+      ).to.be.rejectedWith(
+        'xaml/resourceDictionary cannot emit token aliases with resourceReferenceType "DynamicResource" for token "ColorAlias"; .NET MAUI ResourceDictionary entries must be concrete values. Use "StaticResource" or disable outputReferences.',
+      );
+    });
+
+    it('should throw for unsupported object values', async () => {
+      const tokens = {
+        shadow: {
+          card: {
+            value: {
+              x: 0,
+              y: 1,
+            },
+            type: 'shadow',
+            original: {
+              value: {
+                x: 0,
+                y: 1,
+              },
+            },
+            name: 'ShadowCard',
+            path: ['shadow', 'card'],
+          },
+        },
+      };
+
+      await expect(
+        format(
+          createFormatArgs({
+            dictionary: { tokens, allTokens: convertTokenData(tokens, { output: 'array' }) },
+            file,
+            platform: {},
+          }),
+        ),
+      ).to.be.rejectedWith(
+        'xaml/resourceDictionary does not support object values for token "ShadowCard" with resource type "x:String"',
+      );
+    });
+  });
+});

--- a/docs/src/content/docs/reference/Hooks/Formats/index.md
+++ b/docs/src/content/docs/reference/Hooks/Formats/index.md
@@ -177,6 +177,7 @@ Not all formats use the `outputReferences` option because that file format might
 - [less/variables](/reference/hooks/formats/predefined/#lessvariables)
 - [android/resources](/reference/hooks/formats/predefined/#androidresources)
 - [compose/object](/reference/hooks/formats/predefined/#composeobject)
+- [xaml/resourceDictionary](/reference/hooks/formats/predefined/#xamlresourcedictionary)
 - [ios-swift/class.swift](/reference/hooks/formats/predefined/#ios-swiftclassswift)
 - [flutter/class.dart](/reference/hooks/formats/predefined/#flutterclassdart)
 

--- a/docs/src/content/docs/reference/Hooks/Formats/predefined.md
+++ b/docs/src/content/docs/reference/Hooks/Formats/predefined.md
@@ -674,6 +674,78 @@ object StyleDictionary {
 
 ---
 
+### xaml/resourceDictionary
+
+Creates a .NET MAUI XAML `ResourceDictionary` file with typed resources.
+
+This format is intended for .NET MAUI XAML consumption. It emits concrete resources such as `Color`, `x:String`, `x:Boolean`, and numeric `x:*` values, plus optional `SolidColorBrush` resources keyed with `brushSuffix`.
+
+Compatible primitive coercions are preserved when you override resource types: `Color` accepts common tinycolor-compatible strings and `{ hex }` objects, numeric `x:*` resources accept numbers or numeric strings (including an optional trailing `f`), and `x:Boolean` accepts booleans or `"true"` / `"false"` strings.
+
+When `outputReferences` is enabled, token aliases are emitted as `StaticResource` entries so the dictionary still contains concrete values. `DynamicResource` remains supported for generated brush references, but it is not valid for emitted alias resources in a MAUI `ResourceDictionary`, so `outputReferences: true` combined with `resourceReferenceType: 'DynamicResource'` throws as soon as an alias token is encountered.
+
+For MAUI-friendly output, it is recommended to use PascalCase names and transform sizes into unitless numeric values. For example:
+
+```js title="config.js"
+import { formats, transforms } from 'style-dictionary/enums';
+
+export default {
+  platforms: {
+    xaml: {
+      transforms: [
+        transforms.attributeCti,
+        transforms.namePascal,
+        transforms.colorHex8android,
+        transforms.sizeRemToFloat,
+      ],
+      buildPath: 'build/xaml/',
+      files: [
+        {
+          destination: 'Tokens.xaml',
+          format: formats.xamlResourceDictionary,
+          options: {
+            outputColorBrushes: true,
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+| Param                           | Type                                    | Description                                                                                                                                                                                                                                                                                                                                                                          |
+| ------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `options`                       | `Object`                                |                                                                                                                                                                                                                                                                                                                                                                                      |
+| `options.className`             | `string`                                | Optional `x:Class` value for the generated `ResourceDictionary`.                                                                                                                                                                                                                                                                                                                     |
+| `options.showFileHeader`        | `boolean`                               | Whether or not to include a comment that has the build date. Defaults to `true`.                                                                                                                                                                                                                                                                                                     |
+| `options.outputReferences`      | `boolean \| OutputReferencesFunction`   | Whether or not to keep token aliases as XAML resource aliases when the original token value is a single reference. Defaults to `false`. Aliases are emitted with `StaticResource`, and using this with `resourceReferenceType: 'DynamicResource'` throws when an alias token is encountered. Also allows passing a function to conditionally output references on a per token basis. |
+| `options.resourceReferenceType` | `'StaticResource' \| 'DynamicResource'` | Markup extension used for generated brush references, and for emitted aliases when set to `'StaticResource'`. Defaults to `'StaticResource'`. `DynamicResource` is not supported for emitted alias resources in a MAUI `ResourceDictionary`.                                                                                                                                         |
+| `options.resourceType`          | `string`                                | Forces all tokens in the file to use the same XAML resource element, such as `Color` or `x:String`.                                                                                                                                                                                                                                                                                  |
+| `options.resourceTypeMap`       | `Record<string, string>`                | Maps token types to XAML resource elements. Defaults to `color => Color`, `dimension/fontSize/number => x:Double`, `string/content => x:String`, and `boolean => x:Boolean`.                                                                                                                                                                                                         |
+| `options.outputColorBrushes`    | `boolean`                               | Whether or not to emit `SolidColorBrush` resources for color tokens. Defaults to `false`.                                                                                                                                                                                                                                                                                            |
+| `options.brushSuffix`           | `string`                                | Suffix appended to generated brush resource keys. Defaults to `'Brush'`.                                                                                                                                                                                                                                                                                                             |
+
+Example:
+
+```xaml title="Tokens.xaml"
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Do not edit directly, this file was auto-generated.
+-->
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+  <!-- Brand primary color -->
+  <Color x:Key="ColorBrandPrimary">#FF0B8599</Color>
+  <x:Double x:Key="SizeCornerRadiusMedium">8</x:Double>
+  <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{StaticResource ColorBrandPrimary}" />
+</ResourceDictionary>
+```
+
+Complex object-value tokens such as typography, border, shadow, and transition tokens are not emitted by this format unless they are first transformed into a compatible primitive representation.
+
+---
+
 ### ios/macros
 
 Creates an Objective-C header file with macros for design tokens

--- a/docs/src/content/docs/reference/enums.md
+++ b/docs/src/content/docs/reference/enums.md
@@ -151,6 +151,7 @@ export const formats = {
   stylusVariables: 'stylus/variables',
   typescriptEs6Declarations: 'typescript/es6-declarations',
   typescriptModuleDeclarations: 'typescript/module-declarations',
+  xamlResourceDictionary: 'xaml/resourceDictionary',
 };
 ```
 

--- a/lib/common/formatHelpers/index.js
+++ b/lib/common/formatHelpers/index.js
@@ -12,3 +12,4 @@ export { default as sortByName } from './sortByName.js';
 export { default as minifyDictionary } from './minifyDictionary.js';
 export { default as setSwiftFileProperties } from './setSwiftFileProperties.js';
 export { default as setComposeObjectProperties } from './setComposeObjectProperties.js';
+export { default as setXamlResourceDictionaryProperties } from './setXamlResourceDictionaryProperties.js';

--- a/lib/common/formatHelpers/setXamlResourceDictionaryProperties.js
+++ b/lib/common/formatHelpers/setXamlResourceDictionaryProperties.js
@@ -1,0 +1,91 @@
+/**
+ * @typedef {import('../../../types/Config.d.ts').LocalOptions} Options
+ */
+
+/**
+ * @type {Readonly<Record<string, string>>}
+ */
+const defaultResourceTypeMap = Object.freeze({
+  color: 'Color',
+  dimension: 'x:Double',
+  fontSize: 'x:Double',
+  number: 'x:Double',
+  string: 'x:String',
+  content: 'x:String',
+  boolean: 'x:Boolean',
+});
+
+/**
+ * Outputs an object for XAML ResourceDictionary format configurations.
+ * Sets resource type defaults, reference style and brush options.
+ * @memberof module:formatHelpers
+ * @name setXamlResourceDictionaryProperties
+ * @param {{
+ *   resourceType?: string;
+ *   resourceTypeMap?: Record<string, string>;
+ *   className?: string;
+ *   brushSuffix?: string;
+ *   outputColorBrushes?: boolean;
+ *   resourceReferenceType?: string;
+ * }} [options] - The options object declared at configuration
+ * @returns {Options & {
+ *   resourceTypeMap: Record<string, string>;
+ *   brushSuffix: string;
+ *   outputColorBrushes: boolean;
+ *   resourceReferenceType: 'StaticResource' | 'DynamicResource';
+ * }}
+ */
+export default function setXamlResourceDictionaryProperties(options = {}) {
+  if (typeof options.resourceType !== 'undefined' && typeof options.resourceType !== 'string') {
+    throw new Error(`xaml/resourceDictionary resourceType must be a string`);
+  }
+
+  if (typeof options.className !== 'undefined' && typeof options.className !== 'string') {
+    throw new Error(`xaml/resourceDictionary className must be a string`);
+  }
+
+  if (typeof options.outputColorBrushes === 'undefined') {
+    options.outputColorBrushes = false;
+  } else if (typeof options.outputColorBrushes !== 'boolean') {
+    throw new Error(`xaml/resourceDictionary outputColorBrushes must be a boolean`);
+  }
+
+  if (typeof options.brushSuffix === 'undefined') {
+    options.brushSuffix = 'Brush';
+  } else if (typeof options.brushSuffix !== 'string') {
+    throw new Error(`xaml/resourceDictionary brushSuffix must be a string`);
+  }
+
+  if (typeof options.resourceReferenceType === 'undefined') {
+    options.resourceReferenceType = 'StaticResource';
+  } else if (
+    options.resourceReferenceType !== 'StaticResource' &&
+    options.resourceReferenceType !== 'DynamicResource'
+  ) {
+    throw new Error(
+      `xaml/resourceDictionary resourceReferenceType must be either "StaticResource" or "DynamicResource"`,
+    );
+  }
+
+  if (typeof options.resourceTypeMap === 'undefined') {
+    options.resourceTypeMap = { ...defaultResourceTypeMap };
+  } else if (
+    typeof options.resourceTypeMap !== 'object' ||
+    options.resourceTypeMap === null ||
+    Array.isArray(options.resourceTypeMap)
+  ) {
+    throw new Error(`xaml/resourceDictionary resourceTypeMap must be an object`);
+  } else {
+    for (const [tokenType, resourceType] of Object.entries(options.resourceTypeMap)) {
+      if (typeof resourceType !== 'string') {
+        throw new Error(`xaml/resourceDictionary resourceTypeMap["${tokenType}"] must be a string`);
+      }
+    }
+    options.resourceTypeMap = {
+      ...defaultResourceTypeMap,
+      ...options.resourceTypeMap,
+    };
+  }
+
+  return /** @type {ReturnType<typeof setXamlResourceDictionaryProperties>} */ (options);
+}

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -9,6 +9,7 @@ import {
   sortByName,
   setSwiftFileProperties,
   setComposeObjectProperties,
+  setXamlResourceDictionaryProperties,
 } from './formatHelpers/index.js';
 
 import { stripMeta as stripMetaUtil } from '../utils/stripMeta.js';
@@ -33,6 +34,7 @@ import iosStringsMTemplate from './templates/ios/strings.m.template.js';
 import iosSwiftAnyTemplate from './templates/ios-swift/any.swift.template.js';
 import scssMapDeepTemplate from './templates/scss/map-deep.template.js';
 import scssMapFlatTemplate from './templates/scss/map-flat.template.js';
+import xamlResourceDictionaryTemplate from './templates/xaml/resourceDictionary.xaml.template.js';
 import macrosTemplate from './templates/ios/macros.template.js';
 import plistTemplate from './templates/ios/plist.template.js';
 import {
@@ -105,6 +107,7 @@ const {
   sketchPalette,
   sketchPaletteV2,
   flutterClassDart,
+  xamlResourceDictionary,
 } = fileFormats;
 
 /**
@@ -1172,6 +1175,56 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       options,
     });
     return composeObjectTemplate({ allTokens: sortedTokens, options, formatProperty, header });
+  },
+
+  /**
+   * Creates a .NET MAUI XAML ResourceDictionary file with typed resources.
+   *
+   * @memberof Formats
+   * @kind member
+   * @typedef {Object} xamlResourceDictionaryOpts
+   * @property {string} [xamlResourceDictionaryOpts.className] Optional `x:Class` for the generated ResourceDictionary
+   * @property {string} [xamlResourceDictionaryOpts.resourceType] Force all tokens in the file to use the same XAML resource element
+   * @property {Record<string, string>} [xamlResourceDictionaryOpts.resourceTypeMap] Map token types to XAML resource elements. Defaults to color => `Color`, dimension/fontSize/number => `x:Double`, string/content => `x:String`, boolean => `x:Boolean`
+   * @property {boolean} [xamlResourceDictionaryOpts.outputColorBrushes=false] Whether to emit `SolidColorBrush` resources for color tokens
+   * @property {string} [xamlResourceDictionaryOpts.brushSuffix='Brush'] Suffix appended to generated brush keys
+   * @property {'StaticResource' | 'DynamicResource'} [xamlResourceDictionaryOpts.resourceReferenceType='StaticResource'] Markup extension used for generated brush references, and for emitted aliases when set to `StaticResource`. `DynamicResource` is not supported for emitted alias resources in a MAUI ResourceDictionary
+   * @property {boolean} [xamlResourceDictionaryOpts.showFileHeader=true] Whether or not to include a comment that has the build date
+   * @property {OutputReferences} [xamlResourceDictionaryOpts.outputReferences=false] Whether or not to keep token aliases as XAML resource aliases when a token value is a single reference. Emitted aliases use `StaticResource`, and using this with `resourceReferenceType: 'DynamicResource'` throws when an alias token is encountered
+   * @param {FormatArgs & { options?: xamlResourceDictionaryOpts }} options
+   * @example
+   * ```xaml
+   * <?xml version="1.0" encoding="UTF-8"?>
+   * <ResourceDictionary
+   *   xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+   *   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+   *   <Color x:Key="ColorBrandPrimary">#FF0B8599</Color>
+   *   <SolidColorBrush x:Key="ColorBrandPrimaryBrush" Color="{StaticResource ColorBrandPrimary}" />
+   * </ResourceDictionary>
+   * ```
+   */
+  [xamlResourceDictionary]: async function ({ dictionary, options, file }) {
+    const { allTokens, tokens, unfilteredTokens } = dictionary;
+    const { outputReferences, formatting, usesDtcg } = options;
+
+    const sortedTokens = outputReferences
+      ? [...allTokens].sort(sortByReference(tokens, { unfilteredTokens, usesDtcg }))
+      : allTokens;
+
+    const xamlOptions = setXamlResourceDictionaryProperties(options);
+    const header = await fileHeader({
+      file,
+      commentStyle: xml,
+      formatting: getFormattingCloneWithoutPrefix(formatting),
+      options: /** @type {LocalOptions & Config} */ (xamlOptions),
+    });
+
+    return xamlResourceDictionaryTemplate({
+      dictionary,
+      allTokens: sortedTokens,
+      options: xamlOptions,
+      header,
+    });
   },
 
   // iOS templates

--- a/lib/common/templates/xaml/resourceDictionary.xaml.template.js
+++ b/lib/common/templates/xaml/resourceDictionary.xaml.template.js
@@ -1,0 +1,326 @@
+import Color from 'tinycolor2';
+import usesReferences from '../../../utils/references/usesReferences.js';
+import { getReferences } from '../../../utils/references/getReferences.js';
+import { regexDefault } from '../../../utils/references/createReferenceRegex.js';
+
+/**
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
+ */
+
+const defaultXmlNamespace = 'http://schemas.microsoft.com/dotnet/2021/maui';
+const defaultXmlNamespaceX = 'http://schemas.microsoft.com/winfx/2009/xaml';
+const numericResourceTypes = new Set([
+  'x:Byte',
+  'x:Decimal',
+  'x:Double',
+  'x:Int16',
+  'x:Int32',
+  'x:Int64',
+  'x:Single',
+]);
+
+/**
+ * @param {Token} token
+ * @param {Config} options
+ * @returns {string | boolean | number | object}
+ */
+function getTokenValue(token, options) {
+  return options.usesDtcg ? token.$value : token.value;
+}
+
+/**
+ * @param {Token} token
+ * @param {Config} options
+ * @returns {string | boolean | number | object}
+ */
+function getOriginalTokenValue(token, options) {
+  return options.usesDtcg ? token.original.$value : token.original.value;
+}
+
+/**
+ * @param {Token} token
+ * @param {Config & LocalOptions & { resourceTypeMap: Record<string, string>; resourceType?: string }} options
+ * @returns {string}
+ */
+function getResourceType(token, options) {
+  if (options.resourceType) {
+    return options.resourceType;
+  }
+
+  const tokenType = options.usesDtcg ? token.$type : token.type;
+  if (tokenType && options.resourceTypeMap[tokenType]) {
+    return options.resourceTypeMap[tokenType];
+  }
+
+  const value = getTokenValue(token, options);
+  if (typeof value === 'boolean') return 'x:Boolean';
+  if (typeof value === 'number') return Number.isInteger(value) ? 'x:Int32' : 'x:Double';
+  return 'x:String';
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeXml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function sanitizeComment(value) {
+  return value.replaceAll('--', '- -').replace(/-$/g, '- ');
+}
+
+/**
+ * @param {string | number | boolean | object} value
+ * @param {string} tokenName
+ * @returns {string}
+ */
+function getColorInput(value, tokenName) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'hex' in value &&
+    typeof value.hex === 'string'
+  ) {
+    return value.hex;
+  }
+
+  throw new Error(
+    `xaml/resourceDictionary expected token "${tokenName}" to resolve to a string color value, received ${JSON.stringify(value)}`,
+  );
+}
+
+/**
+ * @param {Token} token
+ * @param {Config} options
+ * @returns {string}
+ */
+function serializeColor(token, options) {
+  const value = getTokenValue(token, options);
+  const colorValue = getColorInput(value, token.name);
+
+  const trimmedValue = colorValue.trim();
+  if (/^#[0-9a-f]{8}$/i.test(trimmedValue)) {
+    return trimmedValue.toUpperCase();
+  }
+  if (/^#[0-9a-f]{6}$/i.test(trimmedValue)) {
+    return `#FF${trimmedValue.slice(1).toUpperCase()}`;
+  }
+
+  const color = Color(colorValue);
+  if (!color.isValid()) {
+    throw new Error(
+      `xaml/resourceDictionary expected token "${token.name}" to resolve to a valid color value, received ${JSON.stringify(value)}`,
+    );
+  }
+
+  const rgb = color.toRgb();
+  /** @param {number} value */
+  const toHex = (value) => Math.round(value).toString(16).padStart(2, '0').toUpperCase();
+  return `#${toHex(rgb.a * 255)}${toHex(rgb.r)}${toHex(rgb.g)}${toHex(rgb.b)}`;
+}
+
+/**
+ * @param {string | number | boolean | object} value
+ * @param {string} tokenName
+ * @returns {string}
+ */
+function serializeNumeric(value, tokenName) {
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  if (typeof value === 'string' && /^-?(?:\d+|\d*\.\d+)(?:f)?$/i.test(value.trim())) {
+    return value.trim().replace(/f$/i, '');
+  }
+
+  throw new Error(
+    `xaml/resourceDictionary expected token "${tokenName}" to resolve to a numeric value, received ${JSON.stringify(value)}`,
+  );
+}
+
+/**
+ * @param {string | number | boolean | object} value
+ * @param {string} resourceType
+ * @param {Token} token
+ * @param {Config} options
+ * @returns {string}
+ */
+function serializeTokenValue(value, resourceType, token, options) {
+  if (resourceType === 'Color') {
+    return serializeColor(token, options);
+  }
+
+  if (resourceType === 'x:Boolean') {
+    if (typeof value === 'boolean') {
+      return value ? 'True' : 'False';
+    }
+    if (value === 'true' || value === 'True') return 'True';
+    if (value === 'false' || value === 'False') return 'False';
+    throw new Error(
+      `xaml/resourceDictionary expected token "${token.name}" to resolve to a boolean value, received ${JSON.stringify(value)}`,
+    );
+  }
+
+  if (numericResourceTypes.has(resourceType)) {
+    return serializeNumeric(value, token.name);
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return escapeXml(String(value));
+  }
+
+  throw new Error(
+    `xaml/resourceDictionary does not support object values for token "${token.name}" with resource type "${resourceType}"`,
+  );
+}
+
+/**
+ * @param {string | number | boolean | object} value
+ * @returns {boolean}
+ */
+function isSingleReferenceValue(value) {
+  if (typeof value !== 'string') return false;
+  const trimmedValue = value.trim();
+  const matches = [...trimmedValue.matchAll(regexDefault)];
+  return matches.length === 1 && matches[0][0] === trimmedValue;
+}
+
+/**
+ * @param {Token} token
+ * @param {Dictionary} dictionary
+ * @param {Config & LocalOptions & { resourceReferenceType: 'StaticResource' | 'DynamicResource' }} options
+ * @returns {Token | undefined}
+ */
+function getReferencedToken(token, dictionary, options) {
+  const originalValue = getOriginalTokenValue(token, options);
+  const referenceValue =
+    typeof originalValue === 'string' ||
+    (typeof originalValue === 'object' && originalValue !== null)
+      ? originalValue
+      : undefined;
+  const shouldOutputReference =
+    referenceValue != null &&
+    usesReferences(referenceValue) &&
+    isSingleReferenceValue(referenceValue) &&
+    (typeof options.outputReferences === 'function'
+      ? options.outputReferences(token, { dictionary, usesDtcg: options.usesDtcg })
+      : options.outputReferences);
+
+  if (!shouldOutputReference) {
+    return undefined;
+  }
+
+  return getReferences(referenceValue, dictionary.tokens, {
+    unfilteredTokens: dictionary.unfilteredTokens,
+    usesDtcg: options.usesDtcg,
+    warnImmediately: false,
+  })[0];
+}
+
+/**
+ * @param {Token} token
+ * @param {string} resourceType
+ * @param {string} body
+ * @returns {string}
+ */
+function createResourceLine(token, resourceType, body) {
+  return `  <${resourceType} x:Key="${escapeXml(token.name)}">${body}</${resourceType}>`;
+}
+
+/**
+ * @param {Token} token
+ * @returns {never}
+ */
+function throwDynamicAliasError(token) {
+  throw new Error(
+    `xaml/resourceDictionary cannot emit token aliases with resourceReferenceType "DynamicResource" for token "${token.name}"; .NET MAUI ResourceDictionary entries must be concrete values. Use "StaticResource" or disable outputReferences.`,
+  );
+}
+
+/**
+ * @param {{
+ *   dictionary: Dictionary;
+ *   allTokens: Token[];
+ *   options: Config & LocalOptions & {
+ *     className?: string;
+ *     outputColorBrushes: boolean;
+ *     brushSuffix: string;
+ *     resourceType?: string;
+ *     resourceTypeMap: Record<string, string>;
+ *     resourceReferenceType: 'StaticResource' | 'DynamicResource';
+ *   };
+ *   header: string;
+ * }} opts
+ */
+export default ({ dictionary, allTokens, options, header }) => {
+  /** @type {string[]} */
+  const resourceLines = [];
+  /** @type {string[]} */
+  const brushLines = [];
+
+  for (const token of allTokens) {
+    const resourceType = getResourceType(token, options);
+    const referencedToken = getReferencedToken(token, dictionary, options);
+    const value = getTokenValue(token, options);
+    const comment = token.$description ?? token.comment;
+
+    if (comment) {
+      resourceLines.push(
+        ...comment.split('\n').map((line) => `  <!-- ${sanitizeComment(line)} -->`),
+      );
+    }
+
+    if (referencedToken) {
+      if (options.resourceReferenceType === 'DynamicResource') {
+        throwDynamicAliasError(token);
+      }
+
+      resourceLines.push(
+        `  <StaticResource x:Key="${escapeXml(token.name)}" Key="${escapeXml(
+          referencedToken.name,
+        )}" />`,
+      );
+    } else {
+      resourceLines.push(
+        createResourceLine(
+          token,
+          resourceType,
+          serializeTokenValue(value, resourceType, token, options),
+        ),
+      );
+    }
+
+    if (options.outputColorBrushes && resourceType === 'Color') {
+      brushLines.push(
+        `  <SolidColorBrush x:Key="${escapeXml(token.name + options.brushSuffix)}" Color="{${
+          options.resourceReferenceType
+        } ${escapeXml(token.name)}}" />`,
+      );
+    }
+  }
+
+  const classNameAttribute = options.className
+    ? `\n  x:Class="${escapeXml(options.className)}"`
+    : '';
+  const resourceSection = [...resourceLines, ...brushLines].join('\n');
+  const body = resourceSection ? `\n${resourceSection}\n` : '\n';
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${header}\n<ResourceDictionary\n  xmlns="${defaultXmlNamespace}"\n  xmlns:x="${defaultXmlNamespaceX}"${classNameAttribute}>${body}</ResourceDictionary>\n`;
+};

--- a/lib/enums/formats.js
+++ b/lib/enums/formats.js
@@ -47,4 +47,5 @@ export const formats = {
   typescriptModuleDeclarations: /** @type {'typescript/module-declarations'} */ (
     'typescript/module-declarations'
   ),
+  xamlResourceDictionary: /** @type {'xaml/resourceDictionary'} */ ('xaml/resourceDictionary'),
 };


### PR DESCRIPTION
Related issue: #977

**Note**: This PR was largely drafted with GitHub Copilot, with my supervision and review. The current implementation and tests look good locally, but I may still be missing edge cases or XAML-specific concerns. I’m not deeply familiar with XAML/.NET MAUI conventions yet, so **_I’d especially appreciate feedback_** on the API shape, generated output, and any improvements that would make this format more idiomatic or robust for real-world use. cc @jorenbroekema @hansmbakker @alexfi1in @AntonKosenkoPro @chazzmoney

## Summary

Adds a new `.NET MAUI` XAML `ResourceDictionary` format for Style Dictionary.

### What’s included

- typed XAML resource output for supported primitive tokens
- optional `SolidColorBrush` generation for color tokens
- configurable resource-type mapping and reference output behavior
- validation for unsupported XAML combinations, including alias output with `DynamicResource`
- test coverage for supported value coercions and formatter behavior

## Notes

`DynamicResource` is supported for generated brush references, but alias resources in a MAUI `ResourceDictionary` must remain concrete values, so alias output is limited to `StaticResource`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
