### PR TITLE
fix: respect expand filters for nested composite tokens

### DIFF
--- a/.changeset/calm-borders-rest.md
+++ b/.changeset/calm-borders-rest.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Limit nested composite token expansion to the configured type filters.

--- a/__tests__/utils/expandObjectTokens.test.js
+++ b/__tests__/utils/expandObjectTokens.test.js
@@ -381,6 +381,56 @@ describe('utils', () => {
           expect(convertTokenData(expanded, { output: 'object' })).to.eql(onlyBorder);
         });
 
+        it('should not expand nested composite tokens excluded by type', () => {
+          const expanded = expandTokens(
+            convertTokenData(
+              {
+                border: {
+                  $type: 'border',
+                  $value: {
+                    color: {
+                      colorSpace: 'lab',
+                      components: [60.17, 90, -60.5],
+                    },
+                    width: '4px',
+                    style: 'solid',
+                  },
+                },
+              },
+              { output: 'map', usesDtcg: true },
+            ),
+            {
+              expand: {
+                include: ['border'],
+              },
+              usesDtcg: true,
+            },
+          );
+
+          expect(convertTokenData(expanded, { output: 'object', usesDtcg: true })).to.eql({
+            border: {
+              color: {
+                key: '{border.color}',
+                $type: 'color',
+                $value: {
+                  colorSpace: 'lab',
+                  components: [60.17, 90, -60.5],
+                },
+              },
+              style: {
+                key: '{border.style}',
+                $type: 'strokeStyle',
+                $value: 'solid',
+              },
+              width: {
+                key: '{border.width}',
+                $type: 'dimension',
+                $value: '4px',
+              },
+            },
+          });
+        });
+
         it('should allow conditionally expanding tokens by type using exclude', () => {
           const expanded = expandTokens(
             convertTokenData({ ...borderInput, ...typographyInput }, { output: 'map' }),

--- a/lib/utils/expandObjectTokens.js
+++ b/lib/utils/expandObjectTokens.js
@@ -176,7 +176,7 @@ export function expandTokenInMap(token, tokenMap, opts, platform) {
       // If the value is an object, we're dealing with a nested composite token and we have to recurse
       // TODO: do we need to also handle recursing array values? Items could be nested objects as well.
       // e.g. a multi-shadow inside a border as a (hypothetical, not realistic) example
-      if (isPlainObject(value) /* || Array.isArray(value)*/) {
+      if (isPlainObject(value) && shouldExpand(expandedValue, opts, platform)) {
         // recurse, and make sure to pass the key so we don't lose the parent relation
         expandTokenInMap(expandedValue, tokenMap, opts, platform);
       } else {


### PR DESCRIPTION
_Issue #, if available:_

fixes https://github.com/style-dictionary/style-dictionary/issues/1661

_Description of changes:_

Apply the configured expand filters before recursing into nested composite token values. This keeps excluded nested token types intact while expanding the selected composite.

Adds regression coverage for an included border token with a nested color token that is not included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
