### PR TITLE
fix(formats): suppress comments when commentStyle is none

### DIFF
--- a/.changeset/shiny-grapes-join.md
+++ b/.changeset/shiny-grapes-join.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Disallow output literal "undefined" for tokens with descriptions when commentStyle is set to none.

--- a/__tests__/common/formatHelpers/createPropertyFormatter.test.js
+++ b/__tests__/common/formatHelpers/createPropertyFormatter.test.js
@@ -507,6 +507,9 @@ describe('common', () => {
           expect(
             addComment('--color-red: #FF0000;', 'Foo bar qux', { commentStyle: none }),
           ).to.equal('--color-red: #FF0000;');
+          expect(addComment('--color-red: #FF0000;', undefined, { commentStyle: short })).to.equal(
+            '--color-red: #FF0000;',
+          );
         });
       });
 

--- a/__tests__/common/formatHelpers/createPropertyFormatter.test.js
+++ b/__tests__/common/formatHelpers/createPropertyFormatter.test.js
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
-import createPropertyFormatter from '../../../lib/common/formatHelpers/createPropertyFormatter.js';
+import createPropertyFormatter, {
+  addComment,
+} from '../../../lib/common/formatHelpers/createPropertyFormatter.js';
 import { convertTokenData } from '../../../lib/utils/convertTokenData.js';
 import { outputReferencesFilter } from '../../../lib/utils/references/outputReferencesFilter.js';
 import { commentStyles, commentPositions, propertyFormatNames } from '../../../lib/enums/index.js';
 
-const { short, long } = commentStyles;
+const { short, long, none } = commentStyles;
 const { above } = commentPositions;
 const { css, sass } = propertyFormatNames;
 
@@ -488,6 +490,23 @@ describe('common', () => {
 
           await expect(cssRed).to.matchSnapshot(1);
           await expect(sassRed).to.matchSnapshot(2);
+        });
+
+        it('should suppress comments when commentStyle is none', () => {
+          const cssFormatter = createPropertyFormatter({
+            format: css,
+            dictionary: { tokens: commentDictionary },
+            formatting: {
+              commentStyle: none,
+            },
+          });
+
+          const output = cssFormatter(commentDictionary.color.red);
+
+          expect(output).to.equal('  --color-red: #FF0000;');
+          expect(
+            addComment('--color-red: #FF0000;', 'Foo bar qux', { commentStyle: none }),
+          ).to.equal('--color-red: #FF0000;');
         });
       });
 

--- a/__tests__/formats/es6Constants.test.js
+++ b/__tests__/formats/es6Constants.test.js
@@ -2,9 +2,10 @@ import { expect } from 'chai';
 import formats from '../../lib/common/formats.js';
 import createFormatArgs from '../../lib/utils/createFormatArgs.js';
 import { convertTokenData } from '../../lib/utils/convertTokenData.js';
-import { formats as fileFormats } from '../../lib/enums/index.js';
+import { commentStyles, formats as fileFormats } from '../../lib/enums/index.js';
 
 const { javascriptEs6 } = fileFormats;
+const { none } = commentStyles;
 
 const file = {
   destination: 'output.js',
@@ -111,6 +112,28 @@ describe('formats', () => {
         }),
       );
       await expect(output).to.matchSnapshot();
+    });
+
+    it('should suppress comments when commentStyle is none', async () => {
+      const output = await format(
+        createFormatArgs({
+          dictionary: {
+            tokens: commentTokens,
+            allTokens: convertTokenData(commentTokens, { output: 'array' }),
+          },
+          file,
+          platform: {},
+          options: {
+            formatting: {
+              commentStyle: none,
+            },
+          },
+        }),
+      );
+
+      expect(output).not.to.include('undefined');
+      expect(output).not.to.include('// comment');
+      expect(output).to.include('export const red = "#EF5350";');
     });
   });
 });

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -37,6 +37,10 @@ export function addComment(to_ret_token, comment, options) {
   const { commentStyle, indentation } = options;
   let { commentPosition } = options;
 
+  if (commentStyle === none) {
+    return to_ret_token;
+  }
+
   const commentsByNewLine = comment.split('\n');
   if (commentsByNewLine.length > 1) {
     commentPosition = above;

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -29,7 +29,7 @@ const defaultFormatting = {
  * Split a string comment by newlines and
  * convert to multi-line comment if necessary
  * @param {string} to_ret_token
- * @param {string} comment
+ * @param {string | undefined} comment
  * @param {Formatting} options
  * @returns {string}
  */
@@ -37,7 +37,7 @@ export function addComment(to_ret_token, comment, options) {
   const { commentStyle, indentation } = options;
   let { commentPosition } = options;
 
-  if (commentStyle === none) {
+  if (!comment || commentStyle === none) {
     return to_ret_token;
   }
 
@@ -158,7 +158,7 @@ export default function createPropertyFormatter({
     ...formatDefaults,
     ...formatting,
   };
-  let { prefix, commentStyle, indentation, separator, suffix } = mergedOptions;
+  let { prefix, indentation, separator, suffix } = mergedOptions;
   const { tokens, unfilteredTokens } = dictionary;
   return function (token) {
     let to_ret_token = `${indentation}${prefix}${token.name}${separator} `;
@@ -248,9 +248,7 @@ export default function createPropertyFormatter({
     to_ret_token += suffix;
 
     const comment = token.$description ?? token.comment;
-    if (comment && commentStyle !== none) {
-      to_ret_token = addComment(to_ret_token, comment, mergedOptions);
-    }
+    to_ret_token = addComment(to_ret_token, comment, mergedOptions);
 
     return to_ret_token;
   };

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -674,9 +674,7 @@ const formats = {
           ...formatting,
         };
 
-        return comment && format.commentStyle !== none
-          ? addComment(to_ret, comment, format)
-          : to_ret;
+        return addComment(to_ret, comment, format);
       }),
     ]
       .flat()
@@ -793,9 +791,7 @@ const formats = {
           ...formatting,
         };
 
-        return comment && format.commentStyle !== none
-          ? addComment(to_ret, comment, format)
-          : to_ret;
+        return addComment(to_ret, comment, format);
       }),
     ]
       .flat()

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -674,7 +674,9 @@ const formats = {
           ...formatting,
         };
 
-        return comment ? addComment(to_ret, comment, format) : to_ret;
+        return comment && format.commentStyle !== none
+          ? addComment(to_ret, comment, format)
+          : to_ret;
       }),
     ]
       .flat()
@@ -791,7 +793,9 @@ const formats = {
           ...formatting,
         };
 
-        return comment ? addComment(to_ret, comment, format) : to_ret;
+        return comment && format.commentStyle !== none
+          ? addComment(to_ret, comment, format)
+          : to_ret;
       }),
     ]
       .flat()


### PR DESCRIPTION
## Issue
Fixes #1727. javascript/es6 and typescript/es6-declarations no longer output literal "undefined" for tokens with descriptions when commentStyle is set to none.

## Description of changes

When using the `javascript/es6` or `typescript/es6-declarations` formats with `commentStyle: "none"`, tokens with a `$description` or `comment` field were producing literal `undefined` in the output instead of suppressing comments.

**Root cause:** `addComment` only handled `short` and `long` comment styles. With `none`, `processedComment` stayed `undefined` and was concatenated into the output string. CSS/SCSS formats already guarded against this in `createPropertyFormatter`, but the JS/TS formats did not.

**Changes:**
1. **`addComment`** — early return when `commentStyle` is `none`, so the token string is returned unchanged.
2. **`javascript/es6` and `typescript/es6-declarations`** — added the same guard used elsewhere: only call `addComment` when a comment exists and `commentStyle !== none`.
3. **Tests** — added coverage in `es6Constants.test.js` and `createPropertyFormatter.test.js`.

**Before:**
```js
export const colorStateBackgroundDisabled = "#f4f5f2";
undefined;
```

**After:**
```js
export const colorStateBackgroundDisabled = "#f4f5f2";
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
