### PR TITLE
fix: preserve CSS alpha precision

### DIFF
--- a/.changeset/preserve-css-alpha-precision.md
+++ b/.changeset/preserve-css-alpha-precision.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Preserve alpha precision in the `color/css` transform.

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -816,6 +816,17 @@ describe('common', () => {
           expect(value).to.equal('#aaaaaa');
         });
 
+        it('should output hex for colors with an alpha of 1', () => {
+          const value = transforms[colorCss].transform(
+            {
+              value: 'rgba(170, 170, 170, 1)',
+            },
+            {},
+            {},
+          );
+          expect(value).to.equal('#aaaaaa');
+        });
+
         it('should handle colors with transparency', () => {
           const value = transforms[colorCss].transform(
             {

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -826,6 +826,29 @@ describe('common', () => {
           );
           expect(value).to.equal('rgba(170, 170, 170, 0.6)');
         });
+
+        it('should preserve legacy alpha precision', () => {
+          const value = transforms[colorCss].transform(
+            {
+              value: 'rgba(0, 0, 0, 0.0625)',
+            },
+            {},
+            {},
+          );
+          expect(value).to.equal('rgba(0, 0, 0, 0.0625)');
+        });
+
+        it('should preserve DTCG alpha precision', () => {
+          const value = transforms[colorCss].transform(
+            {
+              $value: { colorSpace: 'srgb', components: [0, 0, 0], alpha: 0.0625 },
+              $type: 'color',
+            },
+            {},
+            { usesDtcg: true },
+          );
+          expect(value).to.equal('rgba(0, 0, 0, 0.0625)');
+        });
       });
 
       describe(colorSketch, () => {

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -855,11 +855,11 @@ export default {
     filter: isColor,
     transform: function (token, _, options) {
       const color = getColor(token, options);
-      if (color.getAlpha() === 1) {
+      const { r, g, b, a } = color.toRgb();
+      if (a === 1) {
         return color.toHexString();
-      } else {
-        return color.toRgbString();
       }
+      return `rgba(${r}, ${g}, ${b}, ${a})`;
     },
   },
 


### PR DESCRIPTION
## Issue

Related to #1713.

## Description of changes

Thanks for the guidance, @jorenbroekema.

* Preserve the parsed alpha value in `color/css` instead of using tinycolor2's two-decimal string serializer.
* Retain hexadecimal output for opaque colors and the existing output for `0.6` alpha values.
* Add regression coverage for legacy CSS and DTCG sRGB values with alpha `0.0625`.
* Add a patch changeset.

This intentionally does not introduce a configurable precision policy or migrate to ColorJS.io. It preserves the numeric alpha value already parsed by the current transform; it does not preserve lexical spelling such as trailing zeroes.

## Verification

* `npm run lint`
* Node tests: 991 passing, 4 pending.
* Browser tests: 985 passing, 4 skipped.
* Performance tests: 6 passing.
* Node 22.6 strip-types test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
